### PR TITLE
Upgrade django-debug-toolbar

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,2 +1,2 @@
-django-debug-toolbar==1.7
+django-debug-toolbar
 -r requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ bleach==2.0.0
 certifi==2017.4.17
 chardet==3.0.4
 click==6.7
-django-debug-toolbar==1.7
+django-debug-toolbar==1.8
 django-modelcluster==3.1
 django-settings-export==1.2.1
 django-taggit==0.22.1


### PR DESCRIPTION
Closes #26

Wagtail 1.12 fixes the previous issues pinning this to 1.7.

Good catch in the release notes @raq929!