### PR TITLE
Add helper script for running flake8 when developing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,7 @@ dev-restore-db:
 .PHONY: dev-update-requirements
 dev-update-requirements:
 	./devops/scripts/update-requirements.sh
+
+.PHONY: flake8
+flake8:
+	./devops/scripts/run-command-in-venv.sh flake8

--- a/devops/scripts/run-command-in-venv.sh
+++ b/devops/scripts/run-command-in-venv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -f devops/.venv/bin/activate ]; then
+    echo "virtualenv not found, please run make dev-go"
+    exit 1
+fi
+
+source devops/.venv/bin/activate
+$@


### PR DESCRIPTION
This pull request adds the command `make flake8` to check the local files in this project for lintable problems.  I like this because it means all developers will be using the same procedure for flake8, and this will also be the same version of that software employed by CI.

I also tried to implement this in a way that opens the door for easily adding `make` commands that are, essentially, shell commands that should be run in the devops environment.