### PR TITLE
Back to tracking upstream master for django-role

### DIFF
--- a/molecule/ci/playbook.yml
+++ b/molecule/ci/playbook.yml
@@ -22,7 +22,7 @@
     - debug:
         msg: "You can hit the www interface at https://localhost:{{ lookup('pipe', 'docker port debian_jessie_sd.org_ci 443 | cut -d\":\" -f 2') }}"
   roles:
-    - role: freedomofpress.django_stack
+    - role: freedomofpress.django
       tags: django
   vars:
     django_stack_superuser_admin: admin

--- a/molecule/ci/requirements.yml
+++ b/molecule/ci/requirements.yml
@@ -1,4 +1,4 @@
 ---
-- src: https://github.com/freedomofpress/django_stack.git
-  name: freedomofpress.django_stack
-  version: CI_Expand
+- src: https://github.com/freedomofpress/ansible-role-django.git
+  name: freedomofpress.django
+  version: master


### PR DESCRIPTION
Previous branch was a PR and now that this has been merged into master... lets
always track master.

I also did some slight renaming of the role, including
pointing the git URL to the permanent home (repo was recently renamed).

CI should break for all other branches until this one is brought in :| For testing, just verifying that CI passed is good enough.