### PR TITLE
Center footer content on extra small screens

### DIFF
--- a/client/common/sass/_footer.sass
+++ b/client/common/sass/_footer.sass
@@ -124,13 +124,16 @@ $list-bottom-padding: 2rem
 		flex-direction: column
 
 	+media-breakpoint-down(extra-small)
-		display: none
+		align-items: center
 
 .footer-main__nav
 	flex-basis: 25rem
 
 	+media-breakpoint-down(small)
 		flex-basis: 5rem
+	+media-breakpoint-down(extra-small)
+		flex-basis: auto
+		width: 100%
 
 .footer-main__nav-list
 	+list--unstyled
@@ -142,11 +145,15 @@ $list-bottom-padding: 2rem
 	flex-flow: column wrap
 	align-items: flex-start
 	justify-content: center
+	+media-breakpoint-down(extra-small)
+		max-width: 100%
 
 
 .footer-main__nav-item
 	height: $list-item-height
 	min-width: 5rem
+	+media-breakpoint-down(extra-small)
+		width: 50%
 
 .footer-main__nav-link
 	+link--no-underline($gray10--text, $white)


### PR DESCRIPTION
Closes #124 
Additionally now displays the navigation (centered) on mobile:

![image](https://user-images.githubusercontent.com/1051450/31501435-42a7d27c-af38-11e7-9abb-a894ec6e2111.png)
