### PR TITLE
Create error pages

### DIFF
--- a/securedrop/templates/403.html
+++ b/securedrop/templates/403.html
@@ -1,11 +1,12 @@
 {% extends "layout/_layout_one_column.html" %}
+{% load i18n %}
 
-{% block page_title_text %}403 - Securedrop{% endblock %}
+{% block site_title %}403{% endblock %}
+
+{% block page_title_text %}{% trans "Unauthorized" %}{% endblock %}
 
 {% block main %}
-  <div class="error">
-    <h2 class="page-title">You are not authorized to view this page</h2>
-
-    <p class="error__text">Please <a href="{% url 'account_login' %}">sign in</a> and try again.</p>
-  </div>
+  <p>
+    {% trans "You are not authorized to view this page. Please" %} <a href="{% url 'account_login' %}">{% trans "sign in" %}</a> {% trans "and try again." %}
+  </p>
 {% endblock %}

--- a/securedrop/templates/404.html
+++ b/securedrop/templates/404.html
@@ -1,11 +1,10 @@
 {% extends "layout/_layout_one_column.html" %}
+{% load i18n %}
 
-{% block page_title_text %}404 - Securedrop{% endblock %}
+{% block site_title %}404{% endblock %}
+
+{% block page_title_text %}{% trans "Page not found" %}{% endblock %}
 
 {% block main %}
-	<div class="error">
-    <h2 class="page-title">Page not found</h2>
-
-    <p class="error__text">Sorry, this page could not be found.</p>
-  </div>
+  <p>{% trans "Sorry, this page could not be found." %}</p>
 {% endblock %}

--- a/securedrop/templates/500.html
+++ b/securedrop/templates/500.html
@@ -1,11 +1,10 @@
 {% extends "layout/_layout_one_column.html" %}
+{% load i18n %}
 
-{% block page_title_text %}500 - Securedrop{% endblock %}
+{% block site_title %}500{% endblock %}
+
+{% block page_title_text %}{% trans "Internal server error" %}{% endblock %}
 
 {% block main %}
-	<div class="error">
-	    <h2 class="page-title">Internal server error</h2>
-
-	    <p class="error__text">Sorry, there seems to be an error. Please try again soon.</p>
-    </div>
+	<p>{% trans "Sorry, there seems to be an error. Please try again soon." %}</p>
 {% endblock %}


### PR DESCRIPTION
Essentially the same as pressfreedom tracker, with the addition of a 403.
Close #223 

**To Review**
Add the code below to `securedrop.urls.py`. Navigate to `500` etc to see the pages.
```diff
+from django.views.generic.base import TemplateView
 
 
 urlpatterns = [
...
     url(r'^github/', include('github.urls')),
     url(r'^accounts/', include('allauth.urls')),
     url(r'', include(account_urls)),
+    url(r'^500/$', TemplateView.as_view(template_name="500.html")),
+    url(r'^404/$', TemplateView.as_view(template_name="404.html")),
+    url(r'^403/$', TemplateView.as_view(template_name="403.html")),
 
     url(r'', include(wagtail_urls)),
 ]
```