### PR TITLE
Limit homepage instances to 3 on mobile

### DIFF
--- a/client/common/sass/home/_instances.sass
+++ b/client/common/sass/home/_instances.sass
@@ -26,7 +26,15 @@
 	flex-wrap: wrap
 	justify-content: space-between
 	width: 100%
+
 	+media-breakpoint-down(extra-small)
+		display: none
+
+.instances__items--mobile
+	display: none
+
+	+media-breakpoint-down(extra-small)
+		display: flex
 		flex-direction: column
 		width: auto
 		margin: 0 auto

--- a/home/templates/home/_instances.html
+++ b/home/templates/home/_instances.html
@@ -1,0 +1,21 @@
+{% load wagtailcore_tags wagtailimages_tags  %}
+{% for highlighted_instance in instances %}
+  <div class="instances__item">
+    {% if instance.specific.organization_logo %}
+      {% image instance.specific.organization_logo width-144 class="instances__logo" %}
+    {% else %}
+      {% include "common/_hexagon.svg" with class="instances__logo instances__logo--hexagon" category_slug="instance-table" %}
+    {% endif %}
+    <div>
+      <h3 class="instances__item-header">{{ highlighted_instance.instance.title }}</h3>
+      {% if highlighted_instance.instance.organization_description %}
+        <div class="instances__item-description">
+          {{ highlighted_instance.instance.organization_description|richtext|truncatewords_html:20 }}
+        </div>
+      {% endif %}
+      <a href="{% pageurl highlighted_instance.instance %}" class="instances__item-link">
+        {{ page.instance_link_default_text }}
+      </a>
+    </div>
+  </div>
+{% endfor %}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -72,28 +72,14 @@
 			<div class="instances__content">
 
 				<h2 class="instances__header">{{ page.instances_header }}</h2>
-				<div class="instances__items">
-					{% for highlighted_instance in page.instances.all %}
-						<div class="instances__item">
-							{% if instance.specific.organization_logo %}
-								{% image instance.specific.organization_logo width-144 class="instances__logo" %}
-							{% else %}
-								{% include "common/_hexagon.svg" with class="instances__logo instances__logo--hexagon" category_slug="instance-table" %}
-							{% endif %}
-							<div>
-								<h3 class="instances__item-header">{{ highlighted_instance.instance.title }}</h3>
-								{% if highlighted_instance.instance.organization_description %}
-									<div class="instances__item-description">
-										{{ highlighted_instance.instance.organization_description|richtext|truncatewords_html:20 }}
-									</div>
-								{% endif %}
-								<a href="{% pageurl highlighted_instance.instance %}" class="instances__item-link">
-									{{ page.instance_link_default_text }}
-								</a>
-							</div>
-						</div>
-					{% endfor %}
-				</div>
+				{% with instances=page.instances.all %}
+					<div class="instances__items">
+						{% include "home/_instances.html" %}
+					</div>
+					<div class="instances__items instances__items--mobile">
+						{% include "home/_instances.html" with instances=instances|slice:":3" %}
+					</div>
+				{% endwith %}
 				{% for button in page.instance_button.all %}
 					<a href="{% pageurl button.link %}" class="instances__button">
 						{{ button.text }}


### PR DESCRIPTION
Close #198

**To Review**
1. Add more than three instances to the homepage
1. Verify that all of them are displayed when not on mobile, and only 3 are displayed on mobile.