### PR TITLE
Fix result groups delete command.

### DIFF
--- a/directory/management/commands/createresultgroups.py
+++ b/directory/management/commands/createresultgroups.py
@@ -22,6 +22,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options['delete']:
             ResultGroup.objects.all().delete()
+            ResultState.objects.all().delete()
 
         basic, _ = ResultGroup.objects.get_or_create(name='Basic')
         https, _ = ResultGroup.objects.get_or_create(name='HTTPS')


### PR DESCRIPTION
Actually deletes all the things

**To review**
1. Run `docker exec sd_django ./manage.py createresultgroups`
1. Run `docker exec sd_django ./manage.py createresultgroups --delete`
1. Verify that there are no duplicates in resultgroups. (In the admin Snippets -> Result Groups)