### PR TITLE
Remove unneeded print statements

### DIFF
--- a/landing_page_checker/landing_page/scanner.py
+++ b/landing_page_checker/landing_page/scanner.py
@@ -46,9 +46,6 @@ def scan(securedrop):
             http_status_200_ok=False,
         )
 
-    print(pshtt_results['HSTS Max Age'])
-    print(pshtt_results['HSTS Preloaded'])
-
     return Result(
         securedrop=securedrop,
         live=pshtt_results['Live'],


### PR DESCRIPTION
Added for debugging. 

These were causing the command to fail when pssht did not set these variables, I think? At any rate, when I removed the print statements, it got rid of the error. 

Close #333 

**To Review**

1. Have some securedrops added via Wagtail. 
2. Run `docker exec -it sd_django ./manage.py scan`
3. If it doesn't error, you win!