### PR TITLE
Only apply basic-form mixin to forms

### DIFF
--- a/client/common/sass/_allauth.sass
+++ b/client/common/sass/_allauth.sass
@@ -1,5 +1,6 @@
 .allauth
-	+basic-form
+	form
+		+basic-form
 
 	button,
 	.button


### PR DESCRIPTION
Was accidentally applied to all text

Close #317 

**To review**
Go to login form, verify that text looks normal. 