### PR TITLE
Prevent non-routable pages from being indexed

### DIFF
--- a/search/tests/test_search_documents_wagtail.py
+++ b/search/tests/test_search_documents_wagtail.py
@@ -29,6 +29,19 @@ class WagtailTestCase(TestCase):
             1
         )
 
+    def test_non_routable_wagtail_page(self):
+        # Wagtail can only route a page if it starts with the same
+        # path as Site.root_page.url, which in the case of this test
+        # is '/', so the non-routable URL should not start with '/'.
+        page = HomePageFactory.build(path='non_root_route')
+        index_wagtail_page(page)
+
+        # Document should not be created nor errors raised
+        self.assertEqual(
+            SearchDocument.objects.filter(key=KEY_FORMAT.format(page.pk)).count(),
+            0
+        )
+
     def test_index_wagtail_page_signal(self):
         page = self.page
         page.save_revision()

--- a/search/utils/wagtail.py
+++ b/search/utils/wagtail.py
@@ -19,6 +19,10 @@ def index_wagtail_page(page):
     if page.is_root():
         return
 
+    # We can't index non-routable pages
+    if page.full_url is None:
+        return
+
     # Get search content from page instance
     search_content = page.get_search_content() if hasattr(page, 'get_search_content') else ''
 


### PR DESCRIPTION
This fixes #238 -- a bug that could cause the `update_wagtail_index` management command to fail if non-routable pages (or other pages without a URL) were present on the site.