### PR TITLE
Consistency in allauth buttons

### DIFF
--- a/client/common/sass/_allauth.sass
+++ b/client/common/sass/_allauth.sass
@@ -3,12 +3,14 @@
 		+basic-form
 
 	button,
-	.button
+	.button,
+	input[type="submit"]
 		+button-small
 		margin-right: 0.5rem
 
 	.primaryAction,
-	button[type="submit"]
+	button[type="submit"],
+	input[type="submit"]
 		+button-solid--blue
 
 	.secondaryAction,


### PR DESCRIPTION
Unfortunately it seems like allauth was somewhat inconsistent with their templates. Fixes the button on accounts/password/reset/

**To Review**
Go to login and click "Forgot Password". The submit button should be big and blue rather than small and gray.