### PR TITLE
Set a default line-height.

### DIFF
--- a/client/common/sass/base/_base.sass
+++ b/client/common/sass/base/_base.sass
@@ -15,6 +15,7 @@ body
 	font-size: $base
 	font-family: $sans-serif
 	font-weight: $sans-regular
+	line-height: 1.5
 
 b,
 strong


### PR DESCRIPTION
FF had a bad default.
closes #356 