### PR TITLE
Add migration to update site name and domain

### DIFF
--- a/common/migrations/0007_auto_20171117_2121.py
+++ b/common/migrations/0007_auto_20171117_2121.py
@@ -18,6 +18,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('common', '0006_merge_20171117_1652'),
+        ('sites', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
This updates the *django* site name, as opposed to the wagtail site
name.

Fixes #379 