### PR TITLE
Add `get_help_text` method to ZxcvbnValidator

### DIFF
--- a/accounts/password_validation.py
+++ b/accounts/password_validation.py
@@ -20,3 +20,9 @@ class ZxcvbnValidator(object):
             if not messages:
                 messages = 'Use a stronger password.'
             raise ValidationError(messages)
+
+    def get_help_text(self):
+        return (
+            'Passwords must be strong. Avoid common passwords, names, '
+            'english words, dates, sequences, and l33t speak.'
+        )


### PR DESCRIPTION
This method is required for password validators as documented:
https://docs.djangoproject.com/en/1.11/topics/auth/passwords/#writing-your-own-validator

Previously this was causing an error on the create user page in
the Wagtail admin.

Resolves #392
Resolves #416