### PR TITLE
Add CSP for securedrop.org

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,7 @@ defusedxml==0.5.0
 django-allauth-2fa==0.4.4
 django-allauth==0.34.0
 django-anymail[mailgun]==1.4
+django-csp==3.4
 django-debug-toolbar==1.9.1
 django-modelcluster==3.1
 django-otp==0.4.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -24,5 +24,6 @@ wagtail-metadata
 unittest-xml-reporting
 django-allauth==0.34.0
 django-allauth-2fa
+django-csp
 zxcvbn-python
 safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ defusedxml==0.5.0         # via python3-openid
 django-allauth-2fa==0.4.4
 django-allauth==0.34.0
 django-anymail[mailgun]==1.4
+django-csp==3.4
 django-modelcluster==3.1
 django-otp==0.4.1.1       # via django-allauth-2fa
 django-recaptcha==1.3.1

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -109,6 +109,9 @@ MIDDLEWARE = [
     # flow is reset if another page is loaded between login and successfully
     # entering two-factor credentials.
     'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
+
+    # Middleware for content security policy
+    'csp.middleware.CSPMiddleware',
 ]
 
 ROOT_URLCONF = 'securedrop.urls'
@@ -346,3 +349,35 @@ LOGGING = {
         },
     },
 }
+
+# Content Security Policy
+# script:
+# unsafe-eval for client/common/js/common.js:645 and /client/tor/js/torEntry.js:89
+# jquery for wagtail/django debug
+# All for inline scripts in wagtail (admin) login page line 44 and 92
+# style:
+# #1 through #8needed for inline style for svg in sliding-nav:
+# #9 and #10 hashes needed for inline style for modernizr on admin page
+# #11 needed for wagtail admin
+
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    'http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js',
+    "'unsafe-eval'",
+)
+CSP_STYLE_SRC = (
+    "'self'",
+    "'sha256-kRJHclfjr7e5UYWHxtr0Bzdv2BiUtaSbDQe69HgEqXM='",
+    "'sha256-cMOfJ1K7bmWDFQ9IoI+B6fO37u9xMiBgP1rpm79IayM='",
+    "'sha256-Pf5JUUfhnnTVCCmSWFJ3qi/1j67vD2TeYvr7T6LxfqY='",
+    "'sha256-aJumNcjgS5IN0N559UWLFNCtnIIo3CqO862elt0w1A0='",
+    "'sha256-Rg1ua3eExI+in3cF/PWaHTHMjpiLQz/jTlIXr2kBY38='",
+    "'sha256-Zbh/ZO0Ff1YEynn0zSl56u5itxZmwkCVF3PgnnOm8u4='",
+    "'sha256-4ieA95gpQdpg9JDmuID1CQF8dJ/U0JnDqE4GQecAIdg='",
+    "'sha256-LAw02AamnUpPKuSLFUcg9Kh2SLuqSmaXiiV45Y21f84='",
+)
+CSP_IMG_SRC = ("'self'",)
+CSP_FRAME_SRC = ("'self'",)
+CSP_CONNECT_SRC = ("'self'",)
+CSP_EXCLUDE_URL_PREFIXES = ("/admin", )

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -353,7 +353,6 @@ LOGGING = {
 # Content Security Policy
 # script:
 # unsafe-eval for client/common/js/common.js:645 and /client/tor/js/torEntry.js:89
-# jquery for wagtail/django debug
 # All for inline scripts in wagtail (admin) login page line 44 and 92
 # style:
 # #1 through #8needed for inline style for svg in sliding-nav:
@@ -363,7 +362,6 @@ LOGGING = {
 CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
-    'http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js',
     "'unsafe-eval'",
 )
 CSP_STYLE_SRC = (


### PR DESCRIPTION
Adds an initial CSP to securedrop.org website using  django-csp to requirements and middleware.

CSP is mostly a defense-in-depth solution, and shouldn't break functionality. We can slowly iterate on this policy:

- The big win here is that we disable `unsafe-inline` JavaScript.
- Hashes are used for white listing inline style, which shouldn't break site functionality but could break appearance on upgrades. We should ensure there are no CSP style errors on upgrades.
- `unsafe-eval` is required for client/common/js/common.js:645 and /client/tor/js/torEntry.js:89. We should consider fixing this, as it would be another big win.

We should also investigate using a `report-uri` (to which CSP violations are reported to) to both detect errors in the policy, and be aware of potential attack vectors (obviously while preserving user privacy and in line as the currently level of logging)