### PR TITLE
Perform nightly security checks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 jobs:
-  build:
+  safety_check:
     machine: true
     working_directory: ~/securedrop.org
     steps:
@@ -25,6 +25,19 @@ jobs:
           command: |
             make bandit
 
+  build:
+    machine: true
+    working_directory: ~/securedrop.org
+    steps:
+      - checkout
+
+      - run:
+          name: Install testing pre-reqs
+          command: |
+            virtualenv ~/.venv
+            . ~/.venv/bin/activate
+            pip install -r devops/requirements.txt
+
       - run:
           name: Flake8 linting
           command: |
@@ -38,3 +51,20 @@ jobs:
 
       - store_test_results:
           path: ~/securedrop.org/test-results
+
+workflows:
+  version: 2
+  freedomdotpress_ci:
+    jobs:
+      - safety_check
+      - build
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - safety_check

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ flake8: ## Runs flake8 linting in Python3 container.
 bandit: ## Runs bandit static code analysis in Python3 container.
 	@docker run -v $(PWD):/code -w /code --name fpf_www_flake8 --rm \
 		quay.io/freedomofpress/ci-python \
-		bash -c "pip install -q bandit && bandit --recursive . -ll --exclude devops,node_modules,molecule,.venv"
+		bash -c "pip install -q --upgrade bandit && bandit --recursive . -ll --exclude devops,node_modules,molecule,.venv"
 
 .PHONY: clean
 clean: ## clean out local developer assets
@@ -95,13 +95,15 @@ clean: ## clean out local developer assets
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
+# Upgrade safety to ensure we are using the latest version.
 # Using `--stdin` because `-r` was showing inscrutable errors
-	@for req_file in `find . -type f -name '*requirements.txt'`; do \
-		echo "Checking file $$req_file" \
-		&& safety check --full-report --stdin < $$req_file \
-		&& echo -e '\n' \
-		|| exit 1; \
-	done
+	pip install --upgrade safety && \
+		for req_file in `find . -type f -name '*requirements.txt'`; do \
+			echo "Checking file $$req_file" \
+			&& safety check --full-report --stdin < $$req_file \
+			&& echo -e '\n' \
+			|| exit 1; \
+		done
 
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://circleci.com/gh/freedomofpress/securedrop.org.svg?style=svg&circle-token=ae1bdad92b508cea5a86c6a84374af0ae3cf9706
+    :target: https://circleci.com/gh/freedomofpress/securedrop.org
+
 Development
 =============
 This README covers how to install and get started with development in this repository. Information for Wagtail editors can be found in the `Wagtail Editors Guide <WAGTAIL.rst>`_.


### PR DESCRIPTION
- Ensures the latest version of `bandit` and `safety` are installed each time CI runs
- De-couple `safety_check` workflow which will be run daily. It will also be run on each PR, in conjunction with the `build` workflow.