### PR TITLE
Add csp report URI for securedrop.org

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -382,3 +382,4 @@ CSP_IMG_SRC = (
 CSP_FRAME_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'",)
 CSP_EXCLUDE_URL_PREFIXES = ("/admin", )
+CSP_REPORT_URI = ('https://freedomofpress.report-uri.com/r/d/csp/enforce')

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -382,4 +382,7 @@ CSP_IMG_SRC = (
 CSP_FRAME_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'",)
 CSP_EXCLUDE_URL_PREFIXES = ("/admin", )
-CSP_REPORT_URI = ('https://freedomofpress.report-uri.com/r/d/csp/enforce')
+
+# Report URI must be a string, not a tuple.
+CSP_REPORT_URI = os.environ.get('DJANGO_CSP_REPORT_URI',
+                                'https://freedomofpress.report-uri.com/r/d/csp/enforce')


### PR DESCRIPTION
Adds the CSP report uri for securedrop.org

Now that the freedom.press uri works, we can test it with securedrop.org in our next staging deployment. Report URI also allows us to filter by domain name.