### PR TITLE
Fix multi-directive Cache-Control header validation

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -203,6 +203,13 @@ def validate_security_header(page, header, expected_value):
         return False
 
 
+def validate_cache_control_header(page, expected_directive):
+    header = page.headers.get('Cache-Control', '')
+    directives = [directive.lower().strip() for directive in header.split(',')]
+
+    return expected_directive in directives
+
+
 def validate_no_redirects(page):
     if page.is_redirect:
         return False
@@ -331,23 +338,23 @@ def validate_cache_control_set(page):
 
 
 def validate_cache_must_revalidate(page):
-    return validate_security_header(page, "Cache-Control", "must-revalidate")
+    return validate_cache_control_header(page, 'must-revalidate')
 
 
 def validate_nocache(page):
-    return validate_security_header(page, "Cache-Control", "no-cache")
+    return validate_cache_control_header(page, 'no-cache')
 
 
 def validate_nostore(page):
-    return validate_security_header(page, "Cache-Control", "no-store")
+    return validate_cache_control_header(page, 'no-store')
 
 
 def validate_notransform(page):
-    return validate_security_header(page, "Cache-Control", "no-transform")
+    return validate_cache_control_header(page, 'no-transform')
 
 
 def validate_private(page):
-    return validate_security_header(page, "Cache-Control", "private")
+    return validate_cache_control_header(page, 'private')
 
 
 def validate_no_referrer_policy(page):

--- a/scanner/tests/test_validation.py
+++ b/scanner/tests/test_validation.py
@@ -6,6 +6,52 @@ from django.test import TestCase
 from scanner import scanner
 
 
+class MultipleCacheControlDirectivesSuccess(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.page.headers = {
+            'Cache-Control': 'private, max-age=0, no-store, no-cache, must-revalidate, no-transform'
+        }
+
+    def test_cache_control_must_revalidate_set(self):
+        self.assertTrue(scanner.validate_cache_must_revalidate(self.page))
+
+    def test_cache_control_nocache_set(self):
+        self.assertTrue(scanner.validate_nocache(self.page))
+
+    def test_cache_control_notransform_set(self):
+        self.assertTrue(scanner.validate_notransform(self.page))
+
+    def test_cache_control_nostore_set(self):
+        self.assertTrue(scanner.validate_nostore(self.page))
+
+    def test_cache_cache_control_private_set(self):
+        self.assertTrue(scanner.validate_private(self.page))
+
+
+class MultipleCacheControlDirectivesFailure(TestCase):
+    def setUp(self):
+        self.page = mock.Mock()
+        self.page.headers = {
+            'Cache-Control': 'public, max-age=0, store, cache, must-not-revalidate, transform'
+        }
+
+    def test_cache_control_must_revalidate_set(self):
+        self.assertFalse(scanner.validate_cache_must_revalidate(self.page))
+
+    def test_cache_control_nocache_set(self):
+        self.assertFalse(scanner.validate_nocache(self.page))
+
+    def test_cache_control_notransform_set(self):
+        self.assertFalse(scanner.validate_notransform(self.page))
+
+    def test_cache_control_nostore_set(self):
+        self.assertFalse(scanner.validate_nostore(self.page))
+
+    def test_cache_cache_control_private_set(self):
+        self.assertFalse(scanner.validate_private(self.page))
+
+
 class VerificationUtilityTest(TestCase):
     def test_onion_link_is_in_href(self):
         test_html = "<a href='notavalidaddress.onion'>SecureDrop</a>"


### PR DESCRIPTION
This pull request changes how the `Cache-Control` header is validated. Instead of requiring the header be exactly equal to the desired string, we now break the header string into its component directives by splitting on the comma character. We can then check desired caching directive against the list and mark the attribute on ScanResult as passing or failing accordingly.

Fixes #524 