### PR TITLE
Ensure ScanResult for entry exists before showing warnings

### DIFF
--- a/directory/models/entry.py
+++ b/directory/models/entry.py
@@ -221,7 +221,10 @@ class DirectoryEntry(MetadataPageMixin, Page):
         context = super(DirectoryEntry, self).get_context(request)
         context['show_warnings'] = request.GET.get('warnings') == '1'
         if context['show_warnings']:
-            context['warning_level'] = self.get_live_result().warning_level(self.warnings_ignored)
+            try:
+                context['warning_level'] = self.get_live_result().warning_level(self.warnings_ignored)
+            except ScanResult.DoesNotExist:
+                del context['show_warnings']
 
         return context
 

--- a/directory/tests/test_directory_warnings.py
+++ b/directory/tests/test_directory_warnings.py
@@ -8,6 +8,18 @@ from directory.tests.factories import (
 )
 
 
+class DirectoryNoResultsTest(TestCase):
+    def setUp(self):
+        site = Site.objects.get()
+        self.entry = DirectoryEntryFactory(
+            parent=DirectoryPageFactory(parent=site.root_page)
+        )
+
+    def test_warnings_if_no_scan_results_exist(self):
+        response = self.client.get(self.entry.url, {'warnings': '1'})
+        self.assertEqual(response.status_code, 200)
+
+
 class DirectoryNoWarningTest(TestCase):
     def setUp(self):
         site = Site.objects.get()


### PR DESCRIPTION
This pull request addresses a bug wherein a 500 error would occur if someone visited a directory page with `warnings=1` in the query string and no Scan Results existed for that entry.

Fixes #543 