### PR TITLE
Remove warning from `no_cookies` scan result attribute

### DIFF
--- a/directory/models/entry.py
+++ b/directory/models/entry.py
@@ -173,7 +173,6 @@ class DirectoryEntry(MetadataPageMixin, Page):
     )
 
     WARNING_CHOICES = (
-        ('no_cookies', 'Use of Cookies'),
         ('no_cdn', 'Use of CDN'),
         ('no_analytics', 'Use of Analytics'),
         ('subdomain', 'Subdomain'),
@@ -420,7 +419,6 @@ class ScanResult(models.Model):
 
     def warning_level(self, warnings_ignored=[]):
         SEVERE_CONDITIONS = {
-            'no_cookies': False,
             'no_cdn': False,
             'no_analytics': False,
         }

--- a/directory/strings.py
+++ b/directory/strings.py
@@ -1,5 +1,4 @@
 SEVERE_WARNINGS = [
-    ('no_cookies', '{} uses cookies.'),
     ('no_cdn', '{} uses a CDN.'),
     ('no_analytics', '{} uses analytics.'),
 ]

--- a/directory/tests/factories/entry.py
+++ b/directory/tests/factories/entry.py
@@ -117,5 +117,5 @@ class ScanResultFactory(factory.Factory):
         )
         severe_warning = factory.Trait(
             no_failures=True,
-            no_cookies=False,
+            no_analytics=False,
         )

--- a/directory/tests/test_directory_warnings.py
+++ b/directory/tests/test_directory_warnings.py
@@ -143,31 +143,12 @@ class DirectorySevereWarningTest(TestCase):
         )
 
     def test_warning_message_suppressed_if_page_ignores_all_triggered_warnings(self):
-        self.entry.warnings_ignored = ['no_cookies']
+        self.entry.warnings_ignored = ['no_analytics']
         self.entry.save()
         self.entry.refresh_from_db()
         response = self.client.get(self.entry.url, {'warnings': '1'})
         self.assertNotContains(
             response,
             'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/">using the Tor browser</a>, with the <a href="https://safetydocs.example/">safety slider set to "safest"</a>.',
-            status_code=200,
-        )
-
-    def test_single_warning_message_suppressed_if_page_ignores_that_warning(self):
-        self.result.no_analytics = False
-        self.result.save()
-        self.entry.warnings_ignored = ['no_analytics']
-        self.entry.save()
-
-        response = self.client.get(self.entry.url, {'warnings': '1'})
-        self.assertContains(
-            response,
-            'uses cookies',
-            status_code=200,
-        )
-
-        self.assertNotContains(
-            response,
-            'uses analytics',
             status_code=200,
         )

--- a/directory/tests/test_models_entries.py
+++ b/directory/tests/test_models_entries.py
@@ -103,9 +103,9 @@ class ScanResultTest(TestCase):
         result = ScanResultFactory(safe_onion_address=False)
         self.assertEqual(result.warning_level(), 'moderate')
 
-    def test_instance_with_third_party_cookies_gets_severe_warning(self):
+    def test_instance_with_third_party_cookies_gets_no_warning(self):
         result = ScanResultFactory(no_cookies=False)
-        self.assertEqual(result.warning_level(), 'severe')
+        self.assertEqual(result.warning_level(), 'none')
 
     def test_instance_with_analytics_gets_severe_warning(self):
         result = ScanResultFactory(no_analytics=False)


### PR DESCRIPTION
This pull request removes the severe warning attached to a scan result with `no_cookies` set to `True`. I originally included it because I misread the spec in #488.

Fixes #544 