### PR TITLE
Bring warning texts closer to final language.

### DIFF
--- a/directory/strings.py
+++ b/directory/strings.py
@@ -1,10 +1,10 @@
 SEVERE_WARNINGS = [
     ('no_cdn', '{} uses a CDN.'),
-    ('no_analytics', '{} uses analytics.'),
+    ('no_analytics', '{} uses analytics. Visiting this SecureDrop landing page may directly reveal information about your browsing behavior to third parties beyond the organization that operates the SecureDrop instance.'),
 ]
 
 MODERATE_WARNINGS = [
-    ('subdomain', '{0} is hosted on a subdomain, "{domain}", which is unencrypted metadata that may be monitored.'),
-    ('referrer_policy_set_to_no_referrer', '{} uses the wrong referrer policy.'),
-    ('safe_onion_address', '{} contains clickable onion addresses. '),
+    ('subdomain', '{0} is hosted on a subdomain, "{domain}", which is unencrypted metadata that could be monitored by a third party.'),
+    ('referrer_policy_set_to_no_referrer', '{} does not <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy">suppress referrers</a>. Following any links on the page may reveal your visit of the page to third parties.'),
+    ('safe_onion_address', '{} includes a clickable link to a Tor Onion Service (.onion address). Any attempt to visit such a link in a regular browser will fail, but it may be detected by third parties.'),
 ]

--- a/directory/templates/directory/_instance_instructions.html
+++ b/directory/templates/directory/_instance_instructions.html
@@ -54,11 +54,11 @@
 			{% endif %}
 			<div class="instance-alert__content">
 				{% for warning in page.get_warnings %}
-					<p>{{ warning }}</p>
+					<p>{{ warning|safe }}</p>
 				{% endfor %}
 				{% if warning_level == 'severe' %}
 					{% blocktrans %}
-						<p>We strongly advise you to only visit this landing page <a href="https://www.torproject.org/">using the Tor browser</a>, with the <a href="https://safetydocs.example/">safety slider set to "safest"</a>.</p>
+						<p>We strongly advise you to only visit this landing page <a href="https://www.torproject.org/download/download-easy.html.en">using the Tor browser</a>, with the <a href="https://tb-manual.torproject.org/en-US/security-slider.html">security slider</a> set to "safest".</p>
 					{% endblocktrans %}
 				{% elif warning_level == 'moderate' %}
 					{% blocktrans %}

--- a/directory/tests/test_directory_warnings.py
+++ b/directory/tests/test_directory_warnings.py
@@ -103,7 +103,7 @@ class DirectoryModerateWarningTest(TestCase):
 
         self.assertNotContains(
             response,
-            'contains clickable onion addresses',
+            'includes a clickable link to a Tor Onion Service',
             status_code=200,
         )
 
@@ -129,7 +129,7 @@ class DirectorySevereWarningTest(TestCase):
         response = self.client.get(self.entry.url, {'warnings': '1'})
         self.assertContains(
             response,
-            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/">using the Tor browser</a>, with the <a href="https://safetydocs.example/">safety slider set to "safest"</a>.',
+            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/download/download-easy.html.en">using the Tor browser</a>, with the <a href="https://tb-manual.torproject.org/en-US/security-slider.html">security slider</a> set to "safest".',
             status_code=200,
         )
 
@@ -138,7 +138,7 @@ class DirectorySevereWarningTest(TestCase):
         response = self.client.get(self.entry.url)
         self.assertNotContains(
             response,
-            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/">using the Tor browser</a>, with the <a href="https://safetydocs.example/">safety slider set to "safest"</a>.',
+            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/download/download-easy.html.en">using the Tor browser</a>, with the <a href="https://tb-manual.torproject.org/en-US/security-slider.html">security slider</a> set to "safest".',
             status_code=200,
         )
 
@@ -149,6 +149,6 @@ class DirectorySevereWarningTest(TestCase):
         response = self.client.get(self.entry.url, {'warnings': '1'})
         self.assertNotContains(
             response,
-            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/">using the Tor browser</a>, with the <a href="https://safetydocs.example/">safety slider set to "safest"</a>.',
+            'We strongly advise you to only visit this landing page <a href="https://www.torproject.org/download/download-easy.html.en">using the Tor browser</a>, with the <a href="https://tb-manual.torproject.org/en-US/security-slider.html">security slider</a> set to "safest".',
             status_code=200,
         )


### PR DESCRIPTION
As part of this commit, the warning insertion is done as raw HTML,
(usage of  `| safe` in template) to allow for hyperlinks inside
the warning. Tests needed to be updated due to direct string
comparisons.

Resolves #516 (only remaining task)
Resolves #517 (only remaining task)