### PR TITLE
Add User-Agent to the headers in requests made by the scanner

### DIFF
--- a/scanner/assets.py
+++ b/scanner/assets.py
@@ -7,6 +7,7 @@ import tinycss2
 from typing import List
 from bs4 import BeautifulSoup
 
+from scanner.utils import HEADERS
 from scanner.utils import extract_strings, extract_urls
 
 
@@ -174,7 +175,9 @@ def fetch_asset(asset_url: str, site_url: str) -> requests.models.Response:
     if not asset_url.netloc:
         asset_url = asset_url._replace(netloc=site_url.netloc)
 
-    return requests.get(asset_url.geturl())
+    # Note: headers include User-Agent which is required for correct
+    # scanning.
+    return requests.get(asset_url.geturl(), headers=HEADERS)
 
 
 def parse_srcset(srcset: str) -> List[str]:

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -12,7 +12,7 @@ import tldextract
 from django.utils import timezone
 
 from directory.models import ScanResult, DirectoryEntry
-from scanner.utils import url_to_domain
+from scanner.utils import url_to_domain, HEADERS
 from scanner.assets import extract_assets, Asset
 
 if TYPE_CHECKING:
@@ -120,11 +120,22 @@ def bulk_scan(securedrops: 'DirectoryEntryQuerySet') -> None:
 
 def request_and_scrape_page(url: str, allow_redirects: bool = True) -> Tuple[requests.models.Response, BeautifulSoup]:
     """Scrape and parse the HTML of a page into a BeautifulSoup"""
+
+    # Note: headers include User-Agent which is required for correct
+    # scanning.
     try:
-        page = requests.get(url, allow_redirects=allow_redirects)
+        page = requests.get(
+            url,
+            allow_redirects=allow_redirects,
+            headers=HEADERS,
+        )
         soup = BeautifulSoup(page.content, "lxml")
     except requests.exceptions.MissingSchema:
-        page = requests.get('https://{}'.format(url), allow_redirects=allow_redirects)
+        page = requests.get(
+            'https://{}'.format(url),
+            allow_redirects=allow_redirects,
+            headers=HEADERS,
+        )
         soup = BeautifulSoup(page.content, "lxml")
 
     return page, soup

--- a/scanner/tests/test_asset_scraper.py
+++ b/scanner/tests/test_asset_scraper.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from scanner.assets import (
     Asset,
     extract_assets,
+    fetch_asset,
     parse_srcset,
     urls_from_css,
     urls_from_css_declarations,
@@ -260,6 +261,19 @@ class AssetExtractionTestCase(TestCase):
                 ),
             ],
             extract_assets(soup, self.test_url),
+        )
+
+
+class TestAssetFetching(TestCase):
+    @mock.patch('scanner.assets.requests.get')
+    def test_should_send_headers_in_request_for_assets(self, requests_get):
+        asset_url = 'example.gif'
+        site_url = 'http://example.com'
+        fetch_asset(asset_url, site_url)
+
+        requests_get.assert_called_once_with(
+            'http://example.com/example.gif',
+            headers={'User-Agent': 'SecureDrop Landing Page Scanner 0.1.0'},
         )
 
 

--- a/scanner/tests/test_scanner.py
+++ b/scanner/tests/test_scanner.py
@@ -343,6 +343,18 @@ class ScannerTest(TestCase):
         r = scanner.scan(entry, commit=True)
         self.assertIsNotNone(r.forces_https)
 
+    @mock.patch('scanner.scanner.requests.get')
+    def test_should_call_requests_with_correct_arguments(self, requests_get):
+        requests_get.return_value = mock.Mock(content='')
+        scanner.request_and_scrape_page(NON_EXISTENT_URL)
+        requests_get.assert_called_once_with(
+            NON_EXISTENT_URL,
+            allow_redirects=True,
+            headers={
+                'User-Agent': 'SecureDrop Landing Page Scanner 0.1.0',
+            },
+        )
+
 
 class ScannerRedirectionSuccess(TestCase):
     @vcr.use_cassette(os.path.join(VCR_DIR, 'scan-with-good-redirection.yaml'))

--- a/scanner/utils.py
+++ b/scanner/utils.py
@@ -5,6 +5,15 @@ from typing import Set, List
 WEB_URL_REGEX = re.compile(r"""\b((?:https?:\/\/)?(?:[\da-z\.-]+)\.(?:[a-z\.]{2,6})(?:[\/\w\.-?]*)*\/?)""")
 
 
+# Request headers to be sent when the scanner makes requests to a
+# landing page or its assets.  Note that failure to include a
+# User-Agent header can sometimes result in false negatives or other
+# unexpected scan results.
+HEADERS = {
+    'User-Agent': 'SecureDrop Landing Page Scanner 0.1.0',
+}
+
+
 def url_to_domain(url: str) -> str:
     # Split off the protocol
     if len(url.split('//')) > 1:


### PR DESCRIPTION
This header should be sent in every request we make.  Some sites
change their response or perform unexpectedly if no user agent is
given.  We're using, basically, a placeholder string as the value for
the user agent but that might change if it presents problems in the
future.

Fixes #574 