### PR TITLE
Remove warning for a directory entry using a CDN

### DIFF
--- a/directory/tests/test_models_entries.py
+++ b/directory/tests/test_models_entries.py
@@ -112,9 +112,10 @@ class ScanResultTest(TestCase):
         result = ScanResultFactory(no_failures=True, no_analytics=False)
         self.assertEqual(self.securedrop.get_warnings(result)[0].level, WarningLevel.SEVERE)
 
-    def test_instance_with_cdn_gets_severe_warning(self):
+    def test_instance_with_cdn_gets_no_warning(self):
         result = ScanResultFactory(no_failures=True, no_cdn=False)
-        self.assertEqual(self.securedrop.get_warnings(result)[0].level, WarningLevel.SEVERE)
+
+        self.assertEqual(self.securedrop.get_warnings(result), [])
 
     def test_instance_with_cross_domain_assets_gets_severe_warning(self):
         result = ScanResultFactory(no_failures=True, no_cross_domain_assets=False)

--- a/directory/warnings.py
+++ b/directory/warnings.py
@@ -45,13 +45,6 @@ def subdomain_test(scan_result):
         return TestResult.PASS
 
 
-def cdn_test(scan_result):
-    if scan_result.no_cdn:
-        return TestResult.PASS
-    else:
-        return TestResult.FAIL
-
-
 def third_party_asset_test(scan_result):
     if scan_result.no_analytics and scan_result.no_cross_domain_assets:
         return TestResult.PASS
@@ -60,13 +53,6 @@ def third_party_asset_test(scan_result):
 
 
 WARNINGS = [
-    Warning(
-        'no_cdn',
-        cdn_test,
-        WarningLevel.SEVERE,
-        '{} uses a CDN.'
-    ),
-
     Warning(
         'no_third_party_assets',
         third_party_asset_test,


### PR DESCRIPTION
This pull request removes the `no_cdn` warning from our warnings collection.

Fixes #573 