### PR TITLE
Update urllib3 dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ certifi==2017.11.5
 cffi==1.11.2
 chardet==3.0.4
 cryptography==2.3
-dataproperty==0.29.1
+dataproperty==0.36.0
 decorator==4.1.2          # via ipython, traitlets
 defusedxml==0.5.0
 django-allauth-2fa==0.4.4
@@ -25,8 +25,7 @@ django-webpack-loader==0.5.0
 django==1.11.15
 djangorestframework==3.6.4
 docopt==0.6.2
-dominate==2.3.1
-elasticsearch==6.0.0
+dominate==2.3.5
 factory-boy==2.9.2
 faker==0.8.7
 feedparser==5.2.1
@@ -41,14 +40,15 @@ jedi==0.11.0              # via ipython
 logbook==1.1.0
 lxml==4.1.1
 markdown2==2.3.5
-mbstrdecoder==0.2.2
+mbstrdecoder==0.5.0
 mccabe==0.6.1             # via flake8
+msgfy==0.0.4
 multidict==3.3.2
 nassl==1.0.1
 oauthlib==2.0.6
 olefile==0.44
 parso==0.1.0              # via jedi
-pathvalidate==0.16.2
+pathvalidate==0.21.4
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==4.3.0
@@ -62,11 +62,11 @@ pycparser==2.18
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0
 pyopenssl==17.5.0
-pytablewriter==0.27.1
-python-dateutil==2.6.1
+pytablewriter==0.36.1
+python-dateutil==2.7.5
 python-json-logger==0.1.8
 python3-openid==3.1.0
-pytz==2017.3
+pytz==2018.7
 pyyaml==3.12
 qrcode==5.3
 requests-cache==0.4.13
@@ -74,21 +74,19 @@ requests-file==1.4.3
 requests-oauthlib==0.8.0
 requests==2.20.0
 simplegeneric==0.8.1      # via ipython
-simplesqlite==0.19.0
 six==1.11.0
 sqlparse==0.2.3           # via django-debug-toolbar
-tabledata==0.0.5
+tabledata==0.0.25
 text-unidecode==1.1
 tinycss2==0.6.1
 tldextract==2.2.0
 tls-parser==1.1.1
-toml==0.9.3.1
 traitlets==4.3.2          # via ipython
-typepy==0.0.20
+typepy[datetime]==0.3.0
 typing==3.6.4
 unidecode==0.4.21
 unittest-xml-reporting==2.1.0
-urllib3==1.22
+urllib3==1.24.1
 vcrpy==1.11.1
 wagtail-factories==0.3.0
 wagtail-metadata==0.3.1
@@ -98,7 +96,5 @@ webencodings==0.5.1
 wget==3.2
 willow==0.4
 wrapt==1.10.11
-xlsxwriter==1.0.2
-xlwt==1.3.0
 yarl==0.15.0
 zxcvbn-python==4.4.18

--- a/requirements.in
+++ b/requirements.in
@@ -29,3 +29,4 @@ django-allauth-2fa
 django-csp
 zxcvbn-python
 requests>=2.20.0
+urllib3>=1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ beautifulsoup4==4.6.0     # via wagtail
 bleach==2.1.3
 certifi==2017.11.5        # via requests
 cffi==1.11.2              # via cryptography
-chardet==3.0.4            # via requests
+chardet==3.0.4            # via mbstrdecoder, requests
 cryptography==2.3         # via pyopenssl
-dataproperty==0.29.1      # via pytablewriter, simplesqlite, tabledata
+dataproperty==0.36.0      # via pytablewriter, tabledata
 defusedxml==0.5.0         # via python3-openid
 django-allauth-2fa==0.4.4
 django-allauth==0.34.0
@@ -23,23 +23,23 @@ django-webpack-loader==0.5.0
 django==1.11.15
 djangorestframework==3.6.4
 docopt==0.6.2             # via pshtt
-dominate==2.3.1           # via pytablewriter
-elasticsearch==6.0.0      # via pytablewriter
+dominate==2.3.5           # via pytablewriter
 factory-boy==2.9.2
 faker==0.8.7              # via factory-boy
 feedparser==5.2.1
 gunicorn==19.7.1
 html5lib==0.999999999     # via bleach, wagtail
 idna==2.6                 # via cryptography, requests, tldextract
-logbook==1.1.0            # via dataproperty, pytablewriter, simplesqlite, tabledata
+logbook==1.1.0            # via pytablewriter, tabledata
 lxml==4.1.1
 markdown2==2.3.5
-mbstrdecoder==0.2.2       # via pytablewriter, simplesqlite, typepy
+mbstrdecoder==0.5.0       # via dataproperty, pytablewriter, typepy
+msgfy==0.0.4              # via pytablewriter
 multidict==3.3.2          # via yarl
 nassl==1.0.1
 oauthlib==2.0.6           # via requests-oauthlib
 olefile==0.44             # via pillow
-pathvalidate==0.16.2      # via pytablewriter, simplesqlite, tabledata
+pathvalidate==0.21.4      # via pytablewriter, tabledata
 pillow==4.3.0             # via wagtail
 pshtt==0.3.0
 psycopg2==2.7.3.2
@@ -47,30 +47,28 @@ publicsuffix==1.1.0       # via pshtt
 pycparser==2.18           # via cffi
 pygments==2.2.0
 pyopenssl==17.5.0         # via pshtt
-pytablewriter==0.27.1     # via pshtt
-python-dateutil==2.6.1    # via faker, typepy
+pytablewriter==0.36.1     # via pshtt
+python-dateutil==2.7.5    # via faker, typepy
 python-json-logger==0.1.8
 python3-openid==3.1.0     # via django-allauth
-pytz==2017.3              # via django, django-modelcluster, typepy
+pytz==2018.7              # via django, django-modelcluster, typepy
 pyyaml==3.12              # via vcrpy
 qrcode==5.3               # via django-allauth-2fa
 requests-cache==0.4.13    # via pshtt
 requests-file==1.4.3      # via tldextract
 requests-oauthlib==0.8.0  # via django-allauth
 requests==2.20.0
-simplesqlite==0.19.0      # via pytablewriter
-six==1.11.0               # via bleach, cryptography, django-anymail, faker, html5lib, mbstrdecoder, pyopenssl, pytablewriter, python-dateutil, qrcode, requests-file, simplesqlite, tabledata, typepy, unittest-xml-reporting, vcrpy
-tabledata==0.0.5          # via pytablewriter, simplesqlite
+six==1.11.0               # via bleach, cryptography, django-anymail, faker, html5lib, mbstrdecoder, pyopenssl, pytablewriter, python-dateutil, qrcode, requests-file, tabledata, typepy, unittest-xml-reporting, vcrpy
+tabledata==0.0.25         # via pytablewriter
 text-unidecode==1.1       # via faker
 tinycss2==0.6.1
 tldextract==2.2.0
 tls-parser==1.1.1
-toml==0.9.3.1             # via pytablewriter
-typepy==0.0.20            # via dataproperty, pytablewriter, simplesqlite, tabledata
+typepy[datetime]==0.3.0   # via dataproperty, pytablewriter, tabledata
 typing==3.6.4             # via nassl, tls-parser
 unidecode==0.4.21         # via wagtail
 unittest-xml-reporting==2.1.0
-urllib3==1.22             # via elasticsearch, requests
+urllib3==1.24.1
 vcrpy==1.11.1
 wagtail-factories==0.3.0
 wagtail-metadata==0.3.1
@@ -79,7 +77,5 @@ webencodings==0.5.1       # via html5lib, tinycss2
 wget==3.2                 # via pshtt
 willow==0.4               # via wagtail
 wrapt==1.10.11            # via vcrpy
-xlsxwriter==1.0.2         # via pytablewriter
-xlwt==1.3.0               # via pytablewriter
 yarl==0.15.0              # via vcrpy
 zxcvbn-python==4.4.18


### PR DESCRIPTION
Bumping urllib3 to a version >= 1.23 to get around CVE-2018-20060,
see: https://nvd.nist.gov/vuln/detail/CVE-2018-20060

Note: this was only possible to do by upgrading `pytablewriter`
directly, since the older version that had been in use before depended
on urllib3==1.22.  This has had the nice effect of losing some other
unneeded dependencies that are now classified as pytablewriter
extras (e.g. sqlite, elasticsearch).