### PR TITLE
updates due to CVE-2018-7753 and CVE-2018-5773

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/nabla-c0d3/sslyze.git@ef357c2e76b6ba66f23db5fb1f95c7e8a6c13b9d#egg=pshtt-dependency-hell
 asn1crypto==0.23.0
 beautifulsoup4==4.6.0
-bleach==2.1.3
+bleach==3.0.2
 certifi==2017.11.5
 cffi==1.11.2
 chardet==3.0.4
@@ -39,7 +39,7 @@ ipython==6.2.1            # via ipdb
 jedi==0.11.0              # via ipython
 logbook==1.1.0
 lxml==4.1.1
-markdown2==2.3.5
+markdown2==2.3.7
 mbstrdecoder==0.5.0
 mccabe==0.6.1             # via flake8
 msgfy==0.0.4

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 -e git+https://github.com/nabla-c0d3/sslyze.git@ef357c2e76b6ba66f23db5fb1f95c7e8a6c13b9d#egg=pshtt-dependency-hell
-bleach>=2.1.3
+bleach>=2.1.4
 Django>=1.11.18<2
 django-analytical>=2.4
 django-anymail[mailgun]>=1.4
@@ -12,7 +12,7 @@ factory_boy
 feedparser
 gunicorn
 lxml
-markdown2>=2.3.5
+markdown2>=2.3.7
 pshtt==0.3.0
 psycopg2
 pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/nabla-c0d3/sslyze.git@ef357c2e76b6ba66f23db5fb1f95c7e8a6c13b9d#egg=pshtt-dependency-hell
 asn1crypto==0.23.0        # via cryptography
 beautifulsoup4==4.6.0     # via wagtail
-bleach==2.1.3
+bleach==3.0.2
 certifi==2017.11.5        # via requests
 cffi==1.11.2              # via cryptography
 chardet==3.0.4            # via mbstrdecoder, requests
@@ -28,11 +28,11 @@ factory-boy==2.9.2
 faker==0.8.7              # via factory-boy
 feedparser==5.2.1
 gunicorn==19.7.1
-html5lib==0.999999999     # via bleach, wagtail
+html5lib==0.999999999     # via wagtail
 idna==2.6                 # via cryptography, requests, tldextract
 logbook==1.1.0            # via pytablewriter, tabledata
 lxml==4.1.1
-markdown2==2.3.5
+markdown2==2.3.7
 mbstrdecoder==0.5.0       # via dataproperty, pytablewriter, typepy
 msgfy==0.0.4              # via pytablewriter
 multidict==3.3.2          # via yarl
@@ -73,7 +73,7 @@ vcrpy==1.11.1
 wagtail-factories==0.3.0
 wagtail-metadata==0.3.1
 wagtail==1.12.3
-webencodings==0.5.1       # via html5lib, tinycss2
+webencodings==0.5.1       # via bleach, html5lib, tinycss2
 wget==3.2                 # via pshtt
 willow==0.4               # via wagtail
 wrapt==1.10.11            # via vcrpy


### PR DESCRIPTION
Updates due to GitHub security alerts: 

* CVE-2018-7753: updating bleach to at least 2.1.4 resolves (https://github.com/freedomofpress/securedrop.org/network/alert/requirements.txt/bleach/open) 

* CVE-2018-5773: The GitHub alert doesn't reflect this right now, but the project maintainer fixed in https://github.com/trentm/python-markdown2/pull/315, which was included in 2.3.7, so updating to this latest version should resolve. 