### PR TITLE
Skip checking docker component in safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,9 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	pip install --upgrade safety && \
 		for req_file in `find . -type f -name '*requirements.txt'`; do \
 			echo "Checking file $$req_file" \
-			&& safety check --full-report --stdin < $$req_file \
+			&& safety check \
+				-i 36783 \
+				--full-report --stdin < $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \
 		done


### PR DESCRIPTION
Getting us a little past a problem that only affects the dev env. Basically safety check will fail with this error without this fix:

```
-> docker, installed 2.7.0, affected <3.5.1, id 36783
docker 3.5.1 bumps version of `pyOpenSSL` in `requirements.txt` and `setup.py` to prevent
```

HOWEVER, if i bump `docker` -- I start running into a slew of new weird issues I can't explain surrounding the node docker container.