### PR TITLE
Fix dev env docker logs issue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,13 +50,12 @@ services:
       DJANGO_DB_NAME: securedropdb
       DJANGO_DB_PORT: 5432
       DJANGO_DB_HOST: db
-      DJANGO_LOG_PATH: /django-logs
+      DJANGO_LOG_PATH: /django/logs
       DJANGO_XMLTEST_OUTPUT: "yes"
       DEPLOY_ENV: dev
     working_dir: /django
     volumes:
       - ./:/django
-      - ./logs:/django-logs
     ports:
       - "127.0.0.1:8000:8000"
     networks:


### PR DESCRIPTION
Fixes #614

On newly cloned repos, a missing logs directory was
being created via volume mounts with root permissions. This caused
issues when django attempted to write logs there. This logic has changed
over time and did not show up for long-time devs on the folder with
older folders/permissions laying around. This should fix it !