### PR TITLE
Add settings for production-like environments that need debugging

### DIFF
--- a/securedrop/settings/production-debug.py
+++ b/securedrop/settings/production-debug.py
@@ -1,0 +1,6 @@
+from .production import *  # noqa: F403,F401
+
+
+# Enable debugging on production-like systems that are not actually
+# production.
+DEBUG = True


### PR DESCRIPTION
This change adds a settings file for secured production-like
environments that require manual debugging.  All it does is replicate
every other setting from production.py an then switch DEBUG to
true.  This is intended to be used during the sandbox testing.