### PR TITLE
Update docker compose settings to permit PDB use and document how to

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,3 +256,21 @@ If neither of the above fix the issues you're encountering, ensure all docker co
 
     docker-compose rm
     docker-compose up --build
+
+
+Debugging
++++++++++
+
+If you want to use the `PDB <https://docs.python.org/3/library/pdb.html>`_ program for debugging, it is possible.  First, add this line to an area of the code you wish to debug:
+
+.. code:: python
+
+    import ipdb; ipdb.set_trace()
+
+Second, attach to the running Django container.  This must be done in a shell, and it is within this attached shell that you will be able to interact with the debugger.  The command to attach is ``docker attach <ID_OF_DJANGO_CONTAINER>``, and on UNIX-type systems, you can look up the ID and attach to the container with this single command:
+
+.. code:: bash
+
+    docker attach $(docker ps -aqf "name=securedroporg_django")
+
+Once you have done this, you can load the page that will run the code with your ``import ipdb`` and the debugger will activate in the shell you attached.

--- a/README.rst
+++ b/README.rst
@@ -271,6 +271,6 @@ Second, attach to the running Django container.  This must be done in a shell, a
 
 .. code:: bash
 
-    docker attach $(docker ps -aqf "name=securedroporg_django")
+    docker attach $(docker-compose ps -q django)
 
-Once you have done this, you can load the page that will run the code with your ``import ipdb`` and the debugger will activate in the shell you attached.
+Once you have done this, you can load the page that will run the code with your ``import ipdb`` and the debugger will activate in the shell you attached.  To detach from the shell without stopping the container press ``Control+P`` followed by ``Control+Q``.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
       - app
 
   django:
+    stdin_open: true
+    tty: true
     build:
       context: .
       dockerfile: devops/docker/DevDjangoDockerfile


### PR DESCRIPTION
This pull request updates the docker compose settings to permit attaching such that you can interactively run the python debugger on our Django containers. I've also added some documentation for how to do this.

Refs freedomofpress/fpf-www-projects#39