### PR TITLE
Add check-migrations command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
             pipenv run docker-compose -f prod-docker-compose.yaml up -d
             while ! curl --output /dev/null --silent --head --fail http://localhost:8080; do sleep 1 && echo -n .; done;
             pipenv run docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py test --noinput -k"
+            pipenv run docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py makemigrations --dry-run --check"
 
       - store_test_results:
           path: ~/securedrop.org/test-results

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ SD_IMAGE := quay.io/freedomofpress/securedrop.org
 dev-init: ## Initialize docker environment for developer workflow
 	echo UID=$(UID) > .env
 
+.PHONY: check-migrations
+check-migrations: ## Check for ungenerated migrations
+	docker-compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
+
 .PHONY: ci-tests
 ci-tests: ## Runs testinfra against a pre-running CI container. Useful for debug
 	@molecule verify -s ci


### PR DESCRIPTION
This pull request adds a make command to check for ungenerated migrations. I've also put the command into the CI config so it's run when building the site, so that we don't inadvertently merge any PRs without having included all necessary migrations.