### PR TITLE
Add "gitinfo" view

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,5 @@ node_modules
 client/build/
 media/
 molecule
-.git
 **/*.pyc
+.versioninfo

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ results.txt
 
 # Docker-compose env file used for passing userid
 .env
+
+# Ignore files created to communicate system deployment info
+.versioninfo

--- a/common/views.py
+++ b/common/views.py
@@ -3,13 +3,20 @@ import os
 from django.http import HttpResponse
 
 
-GITINFO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'gitinfo')
+DEPLOYINFO_PATH = os.environ.get('DJANGO_VERSION_FILE', '/deploy/version')
 
 
-def gitinfo_view(request):
+def deploy_info_view(request):
+    """Read deployment info file that is written by the deployment system
+
+    This file contains git info (recent commits, messages), python
+    version, dependency versions, and anything else that would be
+    useful for debugging the deployed site.
+
+    """
     try:
-        with open(GITINFO_PATH, 'r') as f:
+        with open(DEPLOYINFO_PATH, 'r') as f:
             contents = f.read()
     except FileNotFoundError:
-        contents = "<file not found at {}>".format(GITINFO_PATH)
+        contents = "<file not found at {}>".format(DEPLOYINFO_PATH)
     return HttpResponse(contents, content_type='text/plain')

--- a/common/views.py
+++ b/common/views.py
@@ -1,0 +1,15 @@
+import os
+
+from django.http import HttpResponse
+
+
+GITINFO_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'gitinfo')
+
+
+def gitinfo_view(request):
+    try:
+        with open(GITINFO_PATH, 'r') as f:
+            contents = f.read()
+    except FileNotFoundError:
+        contents = "<file not found at {}>".format(GITINFO_PATH)
+    return HttpResponse(contents, content_type='text/plain')

--- a/common/wagtail_hooks.py
+++ b/common/wagtail_hooks.py
@@ -7,5 +7,5 @@ from .views import deploy_info_view
 @hooks.register('register_admin_urls')
 def urlconf_time():
     return [
-        url(r'^version/$', deploy_info_view, name='deployinfo'),
+        url(r'^version/?$', deploy_info_view, name='deployinfo'),
     ]

--- a/common/wagtail_hooks.py
+++ b/common/wagtail_hooks.py
@@ -1,0 +1,11 @@
+from wagtail.core import hooks
+from django.conf.urls import url
+
+from .views import gitinfo_view
+
+
+@hooks.register('register_admin_urls')
+def urlconf_time():
+    return [
+        url(r'^gitinfo/$', gitinfo_view, name='gitinfo'),
+    ]

--- a/common/wagtail_hooks.py
+++ b/common/wagtail_hooks.py
@@ -1,11 +1,11 @@
 from wagtail.core import hooks
 from django.conf.urls import url
 
-from .views import gitinfo_view
+from .views import deploy_info_view
 
 
 @hooks.register('register_admin_urls')
 def urlconf_time():
     return [
-        url(r'^gitinfo/$', gitinfo_view, name='gitinfo'),
+        url(r'^version/$', deploy_info_view, name='deployinfo'),
     ]

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -17,8 +17,8 @@ RUN pip install -r /requirements.txt
 ARG USERID
 RUN adduser --uid "${USERID}" --disabled-password --gecos "" gcorn || true
 
-RUN  mkdir /django-logs && \
-    chown -R "$(id -nu):" /django-logs
+RUN  mkdir /django-logs /deploy && \
+    chown -R "${USERID}" /django-logs /deploy
 
 EXPOSE 8000
 USER ${USERID}

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -51,6 +51,10 @@ RUN  mkdir /django-media /django-static /django-logs && \
 RUN mkdir -p /etc/gunicorn && chown -R gcorn: /etc/gunicorn
 COPY devops/docker/gunicorn/gunicorn.py /etc/gunicorn/gunicorn.py
 
+RUN mkdir /deploy && \
+    chown -R gcorn: /deploy && \
+    /django/devops/scripts/version-file.sh
+
 EXPOSE 8000
 USER gcorn
 CMD django-start.sh

--- a/devops/docker/django-start.sh
+++ b/devops/docker/django-start.sh
@@ -28,6 +28,7 @@ django_start() {
         ./manage.py collectstatic -c --noinput
     fi
     if [ "${DEPLOY_ENV}" == "dev" ]; then
+        ./devops/scripts/version-file.sh
         ./manage.py runserver 0.0.0.0:8000
     else
         gunicorn -c /etc/gunicorn/gunicorn.py "${DJANGO_APP_NAME}.wsgi"

--- a/devops/scripts/version-file.sh
+++ b/devops/scripts/version-file.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#
+#
+# Write deployment version information to a file on disk
+
+set -e
+
+DEPLOY_FILE="${DJANGO_VERSION_FILE:-/deploy/version}"
+
+cat /dev/null > "${DEPLOY_FILE}"
+
+echo -e "## GIT INFO #####\n" >> "${DEPLOY_FILE}"
+git log -5 --oneline >> "${DEPLOY_FILE}"
+
+echo -e "\n## PYTHON INFO #####" >> "${DEPLOY_FILE}"
+python --version >> "${DEPLOY_FILE}"
+
+echo -e "\n## PYTHON DEPS #####" >> "${DEPLOY_FILE}"
+pip freeze >> "${DEPLOY_FILE}"
+
+echo -e "\n## SYS INFO #####" >> "${DEPLOY_FILE}"
+cat /etc/issue.net >> "${DEPLOY_FILE}"


### PR DESCRIPTION
This pull request adds a view to the admin area that, essentially, reads from a file and displays those file contents to the admin. In theory, this file is filled with information about the current git commit/branch that's deployed, something like

```
git log HEAD --oneline --no-walk
```