### PR TITLE
Enhance URL Lookups

### DIFF
--- a/directory/models/pages.py
+++ b/directory/models/pages.py
@@ -246,7 +246,10 @@ class DirectoryPage(RoutablePageMixin, MetadataPageMixin, Page):
 
         context = {
             'form': form,
-            'submit_url': '{base}{scan_url}'.format(base=self.url, scan_url=SCAN_URL),
+            'submit_url': '{base}{scan_url}'.format(
+                base=self.get_url(request=request),
+                scan_url=SCAN_URL,
+            ),
             'form_title': self.scanner_form_title,
         }
         if self.scanner_form_text:

--- a/directory/templates/directory/_tag-list.html
+++ b/directory/templates/directory/_tag-list.html
@@ -1,11 +1,13 @@
+{% load wagtailcore_tags %}
+
 <ul class="tag-list">
 	{% for language in page.languages.all %}
-		<li class="tag-list__item"><a class="tag-list__link" href="{{directory.url}}?language={{language.id}}">{{ language }}</a></li>
+		<li class="tag-list__item"><a class="tag-list__link" href="{% pageurl directory %}?language={{language.id}}">{{ language }}</a></li>
 	{% endfor %}
 	{% for country in page.countries.all %}
-		<li class="tag-list__item"><a class="tag-list__link" href="{{directory.url}}?country={{country.id}}">{{ country }}</a></li>
+		<li class="tag-list__item"><a class="tag-list__link" href="{% pageurl directory %}?country={{country.id}}">{{ country }}</a></li>
 	{% endfor %}
 	{% for topic in page.topics.all %}
-		<li class="tag-list__item"><a class="tag-list__link" href="{{directory.url}}?topic={{topic.id}}">{{ topic }}</a></li>
+		<li class="tag-list__item"><a class="tag-list__link" href="{% pageurl directory %}?topic={{topic.id}}">{{ topic }}</a></li>
 	{% endfor %}
 </ul>

--- a/directory/templates/directory/directory_page.html
+++ b/directory/templates/directory/directory_page.html
@@ -112,7 +112,7 @@
 			</div>
 			<div class="submit-instance__buttons">
 				{% if settings.directory.DirectorySettings.allow_directory_management %}
-					<a href="{{page.url}}scan" class="submit-instance__button">
+					<a href="{% pageurl page %}scan" class="submit-instance__button">
 						{{ page.submit_button_text }}
 						{% include "common/chevron-right.svg" with class="submit-instance__button-icon" %}
 					</a>

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -53,7 +53,7 @@
 			<div class="updates__content">
 				<div class="updates__item">
 					<h2 class="updates__header">{% trans "Latest News" %}</h2>
-					<a href="{{ self.get_latest_blog.url }}" class="updates__link">{{ self.get_latest_blog }}</a>
+					<a href="{% pageurl self.get_latest_blog %}" class="updates__link">{{ self.get_latest_blog }}</a>
 				</div>
 				{% with current_release=page.get_current_release %}
 					{% if current_release %}


### PR DESCRIPTION
This pull request replaces, where possible, the use in a template of a page's `url` attribute with wagtail's `pageurl` tag or the `get_url` method.

See freedomofpress/freedom.press#424 for motivation.