### PR TITLE
Upgrade django to 2.1.10

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0
 django-treebeard==4.3
 django-webpack-loader==0.5.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.1
 docopt==0.6.2
 dominate==2.3.5

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 -e git+https://github.com/nabla-c0d3/sslyze.git@ef357c2e76b6ba66f23db5fb1f95c7e8a6c13b9d#egg=pshtt-dependency-hell
 bleach>=2.1.4
-Django>=2.1,<2.2
+Django>=2.1.10,<2.2
 django-analytical>=2.4
 django-anymail[mailgun]>=1.4
 django-modelcluster

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.5.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.1
 docopt==0.6.2             # via pshtt
 dominate==2.3.5           # via pytablewriter


### PR DESCRIPTION
This upgrade fixes a few security vulnerabilities.

This change was generated by modifying requirements.in to require the version we want to upgrade to and running make update-pip-dependencies.

Refs freedomofpress/fpf-www-projects#58