### PR TITLE
Fix mishandled case of Topic Not Found

### DIFF
--- a/directory/models/pages.py
+++ b/directory/models/pages.py
@@ -174,7 +174,7 @@ class DirectoryPage(RoutablePageMixin, MetadataPageMixin, Page):
                 filters['topics'] = Topic.objects.get(id=topic_id)
             except ValueError:
                 pass
-            except Country.DoesNotExist:
+            except Topic.DoesNotExist:
                 pass
 
         return filters

--- a/directory/tests/test_filters.py
+++ b/directory/tests/test_filters.py
@@ -61,6 +61,11 @@ class FiltersFromQueryDictTest(TestCase):
         filters = self.directory.filters_from_querydict(querydict)
         self.assertEqual({}, filters)
 
+    def test_invalid_topic_id_does_not_break_filters(self):
+        querydict = QueryDict('topic=1000000')
+        filters = self.directory.filters_from_querydict(querydict)
+        self.assertEqual({}, filters)
+
     def test_invalid_id_does_not_break_filters(self):
         querydict = QueryDict('language=100000')
         filters = self.directory.filters_from_querydict(querydict)


### PR DESCRIPTION
This pull request corrects a case where, probably due to a copy/paste mishap, we're not catching the correct exception for the case when a `Topic` is missing. This fixes a bug where if a user enters a non-existent topic id, then the site will throw an error.

