### PR TITLE
Upgrade to latest version of npm and supported version of node

### DIFF
--- a/devops/docker/NodeDockerfile
+++ b/devops/docker/NodeDockerfile
@@ -1,8 +1,12 @@
 ARG NODE_VER
+ARG NPM_VER
 FROM node:${NODE_VER}
 
 # Make npm output less verbose
 ENV NPM_CONFIG_LOGLEVEL warn
+
+# Upgrade npm to speicifed version
+RUN npm install npm@${NPM_VER} -g
 
 ARG USERID
 RUN adduser -D -g "" -u "${USERID}" docker_user || true

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -1,8 +1,12 @@
 ARG NODE_VER
+ARG NPM_VER
 FROM node:${NODE_VER} AS node-assets
 
 # Make npm output less verbose
 ENV NPM_CONFIG_LOGLEVEL warn
+
+# Upgrade npm to speicifed version
+RUN npm install npm@${NPM_VER} -g
 
 # Oddly, node-sass requires both python and make to build bindings
 RUN apk add --no-cache paxctl python make g++

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,8 @@ services:
       context: .
       dockerfile: devops/docker/NodeDockerfile
       args:
-        NODE_VER: 10.15.1-alpine
+        NODE_VER: 10.17.0-alpine
+        NPM_VER: 6.13.4
         USERID: ${UID:?err}
     volumes:
       - ./:/django

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -24,7 +24,8 @@ services:
       context: .
       dockerfile: devops/docker/ProdDjangoDockerfile
       args:
-        NODE_VER: 10.15.1-alpine
+        NODE_VER: 10.17.0-alpine
+        NPM_VER: 6.13.4
     image: quay.io/freedomofpress/securedrop.org
     depends_on:
       - postgresql


### PR DESCRIPTION
* In the process I've also extended our NodeDockerfile to allow
  us to easily specify an NPM version as part of the
  docker-compose file
* Since we are still on a supported LTS track with Node 10.x, I
  decided to conservatively upgrade to the latest version of Node
  10.x rather than upgrade to the absolutely latest Node (or even
  the latest LTS track, which is node 12.x)
* Among other things, this patches this vulnerability in npm
  https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli