### PR TITLE
Expands git info on version endpoint

### DIFF
--- a/devops/scripts/version-file.sh
+++ b/devops/scripts/version-file.sh
@@ -11,6 +11,10 @@ DEPLOY_FILE="${DJANGO_VERSION_FILE:-/deploy/version}"
 cat /dev/null > "${DEPLOY_FILE}"
 
 echo -e "## GIT INFO #####\n" >> "${DEPLOY_FILE}"
+git_tag_info="$(git describe --exact-match || echo "N/A")"
+echo -e "git tag: ${git_tag_info}\n" >> "${DEPLOY_FILE}"
+git_branch_info="$(git rev-parse --abbrev-ref HEAD || echo "N/A")"
+echo -e "git branch: ${git_branch_info}\n" >> "${DEPLOY_FILE}"
 git log -5 --oneline >> "${DEPLOY_FILE}"
 
 echo -e "\n## PYTHON INFO #####" >> "${DEPLOY_FILE}"


### PR DESCRIPTION
Specifically, adds info on:

  1. git tag (if HEAD is tagged; otherwise "N/A")
  2. git branch (usually "master", but can be feature branches on
     e.g. staging)

Hopefully this'll be more immediately useful than a simple list of the
commits, as we have now. The list of commits is preserved in these
changes.

Refs https://github.com/freedomofpress/infrastructure/issues/2305

### Before
```
## GIT INFO #####

4dcfefe Merge pull request #662 from freedomofpress/tor-browser-regex-string
68a69e8 Update TB UAS regex to match latest spoofed UAS sent by Tor browser
dc16541 Merge pull request #661 from freedomofpress/wagtail-2-7
9002c2f Explicitly specify `output_field` for instantiated `Value` items
b00b839 Upgrade to Django 2.2
```


### After
```
## GIT INFO #####

git tag: 2020.01.10

git branch: master

4dcfefe Merge pull request #662 from freedomofpress/tor-browser-regex-string
68a69e8 Update TB UAS regex to match latest spoofed UAS sent by Tor browser
dc16541 Merge pull request #661 from freedomofpress/wagtail-2-7
9002c2f Explicitly specify `output_field` for instantiated `Value` items
b00b839 Upgrade to Django 2.2
```

### Testing
If you want to review locally, run `docker-compose up --build`, then navigate to http://localhost:8000/admin/version/ 