### PR TITLE
Centers the securedrop logo

### DIFF
--- a/client/common/sass/_nav-menu.sass
+++ b/client/common/sass/_nav-menu.sass
@@ -29,10 +29,11 @@
 		height: 3rem
 
 .nav-menu__logo
-	width: 2rem
+	width: 2.5rem
 	margin-right: 1rem
 	// Prevents the objects from receiving pointer events instead of the link.
 	pointer-events: none
+	display: flex !important
 
 	*
 		fill: $white


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9530293/75909642-77f44000-5e72-11ea-827c-b724484c191a.png)

Fixes #537 

Hopefully this looks better @harrislapiroff 