### PR TITLE
Update npm-audit-plus to 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5302,9 +5302,9 @@
       "dev": true
     },
     "npm-audit-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/npm-audit-plus/-/npm-audit-plus-0.1.5.tgz",
-      "integrity": "sha512-+jZuobNTzrmHod/Wpby1iqMriXbGcMUeJivHeo7WcJ1E47BNM6aX2EcMe3BO47TfgPTrVReNs7+BBduiv7Fvig==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/npm-audit-plus/-/npm-audit-plus-0.1.7.tgz",
+      "integrity": "sha512-X6hLsc7zsnIlg564gzfdtFSWiMnlN2fnzM7ExSRTj0wcRP1GFvzieUeYfImP7kXAda4x6gjsBcXG/fY29j88sQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -7956,9 +7956,9 @@
       "dev": true
     },
     "xmlbuilder": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-12.0.0.tgz",
-      "integrity": "sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-12.0.1.tgz",
+      "integrity": "sha512-rRjf/JR+sEMqU2o6WEA+iR/YRIegH3P35eiQuCsT1YfZqOS+iu23azPq0igZjpBX+wa7D8gHd845kLPzow7IKg==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "css-loader": "^3.5.1",
     "mini-css-extract-plugin": "^0.5.0",
     "node-sass": "^4.14.1",
-    "npm-audit-plus": "^0.1.5",
+    "npm-audit-plus": "^0.1.7",
     "postcss-loader": "^2.1.6",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",


### PR DESCRIPTION
Fixes a bug where too many vulnerabilities could result in a passing
grade.