### PR TITLE
Ensure CI test job fails when tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ci-tests: ## Runs testinfra against a pre-running CI container. Useful for debug
 
 .PHONY: dev-tests
 dev-tests: ## Run django tests against developer environment
-	docker-compose exec django /bin/bash -c \
+	docker-compose exec django /bin/bash -ec \
 		"coverage run --source='.' ./manage.py test --noinput -k; \
 		coverage html --skip-empty --omit='*/migrations/*.py,*/tests/*.py'; \
 		coverage report -m --fail-under=70 --skip-empty --omit='*/migrations/*.py,*/tests/*.py'"


### PR DESCRIPTION
This pull request adds `-e` to the `make` command's `bash` call used to execute the test suite.

`bash -e` ensures that non-zero exit codes during any "intermediate"
command (e.g. in a sequence of semicolon separated commands, which we
have here) are propagated upwards and the entire call to bash returns
a non-zero code. This is needed so that Circle CI becomes aware that
the test command failed.