### PR TITLE
Add Link to Source Docs on Directory Page

### DIFF
--- a/directory/templates/directory/_instance_instructions.html
+++ b/directory/templates/directory/_instance_instructions.html
@@ -11,7 +11,10 @@
 			and verify that the addresses match before continuing.
 			This provides a strong layer of defense against certain types of attacks
 			that might try to trick you into visiting a malicious SecureDrop instance
-			masquerading as a legitimate one.
+			masquerading as a legitimate one. We would also recommend you to go through the
+			<a href="https://docs.securedrop.org/en/stable/source.html">Source guide</a>
+			for a more comprehensive documentation on SecureDrop Usage and various risks
+			relating to it.
 		{% endblocktrans %}
 	</p>
 	<p>


### PR DESCRIPTION
Fixes #678 

As directory page is one of the first pages any potential source would visit before submitting a document, it's better if we link Source Documentation in the Page. 