### PR TITLE
Update CircleCI image and Python 3.5 version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ reuse-blerbs:
     run:
       name: Install testing pre-reqs
       command: |
-        # Set python to 3.5.2
-        pyenv global 3.5.2
+        # Set python to 3.5.9
+        pyenv global 3.5.9
         pip install -U pip
         pip install pipenv
         pipenv install
@@ -14,7 +14,7 @@ version: 2
 jobs:
   safety_check:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/securedrop.org
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   npm_audit:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/freedom.press
     steps:
       - checkout
@@ -53,7 +53,7 @@ jobs:
 
   build_dev:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/securedrop.org
     steps:
       - checkout
@@ -90,7 +90,7 @@ jobs:
 
   build_prod:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
     working_directory: ~/pressfreedom
     steps:
       - checkout


### PR DESCRIPTION
The Python 3.5 container is on 3.5.9; let's match it. In this case, we were already using a CircleCI 16.04 image, but let's update it to current.