### PR TITLE
Checks the hostname and onion address to see if they match before sending header

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -7,8 +7,10 @@ class OnionLocationMiddleware(object):
 
     def __call__(self, request):
         response = self.get_response(request)
-
         footer_settings = FooterSettings.for_site(request.site)
-        if footer_settings.securedrop_onion_address:
-            response['Onion-Location'] = footer_settings.securedrop_onion_address
+        if (
+            footer_settings.securedrop_onion_address
+            and request.get_host() not in footer_settings.securedrop_onion_address
+        ):
+            response["Onion-Location"] = footer_settings.securedrop_onion_address
         return response


### PR DESCRIPTION
Might fix #698 

I was unable to check the onion location button locally. For some reason the location button doesn't appear when tried with ngrok, so not sure. I am just checking the request host name with the onion address saved. And if they don't match, I send the location header.