### PR TITLE
Change CircleCI nightly job to check out develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - develop
     jobs:
       - safety_check


### PR DESCRIPTION
This is the branch that should be checked every night, master is
obsolete.