### PR TITLE
Removes unrequired safety ignores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	pip install --upgrade safety && \
 		for req_file in `find . -type f -name '*requirements.txt'`; do \
 			echo "Checking file $$req_file" \
-			&& safety check --full-report --stdin --ignore 38449 --ignore 38450 --ignore 38451 --ignore 38452 --ignore 38197 --ignore 38198 < $$req_file \
+			&& safety check --full-report --stdin --ignore 38197 < $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \
 		done


### PR DESCRIPTION
It removes the unnecessary safety ignores right now. Still needed to keep the safety ignore related to sslyze because pshtt still has an older dependency

Refs: https://github.com/freedomofpress/fpf-www-projects/issues/122