### PR TITLE
Use custom endpoint for Google Storage

### DIFF
--- a/common/storage.py
+++ b/common/storage.py
@@ -4,7 +4,9 @@ from storages.backends.gcloud import GoogleCloudStorage
 
 class StaticStorage(GoogleCloudStorage):
     location = settings.GS_STATIC_PATH
+    default_acl = 'publicRead'
 
 
 class MediaStorage(GoogleCloudStorage):
     location = settings.GS_MEDIA_PATH
+    default_acl = 'publicRead'

--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -50,6 +50,9 @@ if os.environ.get('GS_BUCKET_NAME'):
 
     GS_BUCKET_NAME = os.environ['GS_BUCKET_NAME']
 
+    if 'GS_CUSTOM_ENDPOINT' in os.environ:
+        GS_CUSTOM_ENDPOINT = os.environ['GS_CUSTOM_ENDPOINT']
+
     if 'GS_CREDENTIALS' in os.environ:
         from google.oauth2.service_account import Credentials
         GS_CREDENTIALS = Credentials.from_service_account_file(os.environ['GS_CREDENTIALS'])


### PR DESCRIPTION
Closes https://github.com/freedomofpress/infrastructure/issues/2885

We now have the bucket for media files in GS hosted on a custom domain. This updates the django-storages config to use those URLs. The deployment already adds the correct domain to the CSP.

Setting doc: https://django-storages.readthedocs.io/en/latest/backends/gcloud.html