### PR TITLE
Improve ignore handling in safety script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,14 +112,7 @@ clean: ## clean out local developer assets
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 # Upgrade safety to ensure we are using the latest version.
-# Using `--stdin` because `-r` was showing inscrutable errors
-	pip install --upgrade safety && \
-		for req_file in `find . -type f -name '*requirements.txt'`; do \
-			echo "Checking file $$req_file" \
-			&& safety check --full-report --stdin --ignore 38197 < $$req_file \
-			&& echo -e '\n' \
-			|| exit 1; \
-		done
+	pip install --upgrade safety && ./scripts/safety_check.py
 
 .PHONY: prod-push
 prod-push: ## Publishes prod container image to registry

--- a/project.json
+++ b/project.json
@@ -1,0 +1,5 @@
+{
+	"variables": {
+		"SAFETY_IGNORE_IDS": ["38197"]
+	}
+}

--- a/scripts/safety_check.py
+++ b/scripts/safety_check.py
@@ -1,93 +1,13 @@
 #!/usr/bin/env python
-import argparse
-import traceback
 import json
+import traceback
 import glob
 import subprocess
 import sys
+import pathlib
 
 
-IDS_TO_IGNORE = ['38197']
-
-
-class Vulnerability(object):
-    def __init__(self, package, affected_versions, message):
-        self.package = package
-        self.affected_versions = affected_versions
-        self.message = message
-        self.occurrences = []
-
-    def with_occurrence(self, filename, version):
-        self.occurrences.append({'filename': filename, 'version': version})
-        return self
-
-
-class SafetyCheck(object):
-    def __init__(self, ids_to_ignore):
-        self.ignored = {}
-        self.failed = {}
-
-        self.ids_to_ignore = set(ids_to_ignore)
-
-    def to_json(self):
-        return json.dumps(
-            {'ignored': self.ignored, 'failed': self.failed},
-            default=lambda o: o.__dict__,
-            sort_keys=True,
-            indent=4,
-        )
-
-    def add(self, result, filename):
-        package, affected_versions, curr_version, message, vulnerability_id = result
-        if vulnerability_id in self.ids_to_ignore:
-            if vulnerability_id in self.ignored:
-                vuln = self.ignored[vulnerability_id].with_occurrence(
-                    filename=filename, version=curr_version
-                )
-            else:
-                vuln = Vulnerability(package, affected_versions, message).with_occurrence(
-                    filename=filename, version=curr_version
-                )
-            self.ignored[vulnerability_id] = vuln
-        else:
-            if vulnerability_id in self.failed:
-                vuln = self.failed[vulnerability_id].with_occurrence(
-                    filename=filename, version=curr_version
-                )
-            else:
-                vuln = Vulnerability(
-                    package, affected_versions, message
-                ).with_occurrence(filename=filename, version=curr_version)
-            self.failed[vulnerability_id] = vuln
-
-
-def check_json():
-    """Runs `safety` on all requirements files and prints a summary of
-    vulnerabilities in JSON format.  Always exits with a success code
-    (0) unless the summary could not be generated.  Intended to
-    produce JSON that other programs can consume an act upon
-    appropriately.
-
-    """
-    check = SafetyCheck(IDS_TO_IGNORE)
-    for filename in glob.glob('**/*requirements.txt', recursive=True):
-        command = ['safety', 'check', '--json', '-r', filename]
-        try:
-            result = subprocess.run(
-                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-        except subprocess.CalledProcessError as e:
-            output = e.output.decode('utf-8')
-            sys.stderr.write(output)
-            return 1
-        for result in json.loads(result.stdout.decode('utf-8')):
-            check.add(result, filename)
-
-    print(check.to_json())
-    return 0
-
-
-def check_full_report():
+def check_full_report(ids_to_ignore=[]):
     """Runs `safety` on all requirements files, outputs the full report
     for each.  Exits with a success code (0) if all the checks also
     executed with success, and exits with a failure code (1)
@@ -98,7 +18,7 @@ def check_full_report():
     """
     success = True
     command = ['safety', 'check', '--full-report']
-    for ignored_id in IDS_TO_IGNORE:
+    for ignored_id in ids_to_ignore:
         command.extend(['-i', ignored_id])
     for filename in glob.glob('**/*requirements.txt', recursive=True):
         print('Checking {}'.format(filename))
@@ -108,22 +28,15 @@ def check_full_report():
     return 0 if success else 1
 
 
-def main(json_format=False):
-    if json_format:
-        return check_json()
-    else:
-        return check_full_report()
-
-
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Run a security audit of python packages'
-    )
-    parser.add_argument('--json', action='store_true', help='Output results in JSON format')
-    args = parser.parse_args()
+    project_path = pathlib.Path(__file__).parent.parent / "project.json"
+
+    project = json.loads(project_path.read_text())
 
     try:
-        sys.exit(main(json_format=args.json))
-    except Exception as e:
+        sys.exit(
+            check_full_report(project['variables']['SAFETY_IGNORE_IDS'])
+        )
+    except Exception:
         sys.stderr.write(traceback.format_exc())
         sys.exit(1)

--- a/scripts/safety_check.py
+++ b/scripts/safety_check.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+import argparse
+import traceback
+import json
+import glob
+import subprocess
+import sys
+
+
+IDS_TO_IGNORE = ['38197']
+
+
+class Vulnerability(object):
+    def __init__(self, package, affected_versions, message):
+        self.package = package
+        self.affected_versions = affected_versions
+        self.message = message
+        self.occurrences = []
+
+    def with_occurrence(self, filename, version):
+        self.occurrences.append({'filename': filename, 'version': version})
+        return self
+
+
+class SafetyCheck(object):
+    def __init__(self, ids_to_ignore):
+        self.ignored = {}
+        self.failed = {}
+
+        self.ids_to_ignore = set(ids_to_ignore)
+
+    def to_json(self):
+        return json.dumps(
+            {'ignored': self.ignored, 'failed': self.failed},
+            default=lambda o: o.__dict__,
+            sort_keys=True,
+            indent=4,
+        )
+
+    def add(self, result, filename):
+        package, affected_versions, curr_version, message, vulnerability_id = result
+        if vulnerability_id in self.ids_to_ignore:
+            if vulnerability_id in self.ignored:
+                vuln = self.ignored[vulnerability_id].with_occurrence(
+                    filename=filename, version=curr_version
+                )
+            else:
+                vuln = Vulnerability(package, affected_versions, message).with_occurrence(
+                    filename=filename, version=curr_version
+                )
+            self.ignored[vulnerability_id] = vuln
+        else:
+            if vulnerability_id in self.failed:
+                vuln = self.failed[vulnerability_id].with_occurrence(
+                    filename=filename, version=curr_version
+                )
+            else:
+                vuln = Vulnerability(
+                    package, affected_versions, message
+                ).with_occurrence(filename=filename, version=curr_version)
+            self.failed[vulnerability_id] = vuln
+
+
+def check_json():
+    """Runs `safety` on all requirements files and prints a summary of
+    vulnerabilities in JSON format.  Always exits with a success code
+    (0) unless the summary could not be generated.  Intended to
+    produce JSON that other programs can consume an act upon
+    appropriately.
+
+    """
+    check = SafetyCheck(IDS_TO_IGNORE)
+    for filename in glob.glob('**/*requirements.txt', recursive=True):
+        command = ['safety', 'check', '--json', '-r', filename]
+        try:
+            result = subprocess.run(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode('utf-8')
+            sys.stderr.write(output)
+            return 1
+        for result in json.loads(result.stdout.decode('utf-8')):
+            check.add(result, filename)
+
+    print(check.to_json())
+    return 0
+
+
+def check_full_report():
+    """Runs `safety` on all requirements files, outputs the full report
+    for each.  Exits with a success code (0) if all the checks also
+    executed with success, and exits with a failure code (1)
+    otherwise.  Intended to be run in a CI context where the exit code
+    of this command alone determines the pass/fail status of the
+    overall check.
+
+    """
+    success = True
+    command = ['safety', 'check', '--full-report']
+    for ignored_id in IDS_TO_IGNORE:
+        command.extend(['-i', ignored_id])
+    for filename in glob.glob('**/*requirements.txt', recursive=True):
+        print('Checking {}'.format(filename))
+        result = subprocess.run(command + ['-r', filename])
+        if result.returncode != 0:
+            success = False
+    return 0 if success else 1
+
+
+def main(json_format=False):
+    if json_format:
+        return check_json()
+    else:
+        return check_full_report()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Run a security audit of python packages'
+    )
+    parser.add_argument('--json', action='store_true', help='Output results in JSON format')
+    args = parser.parse_args()
+
+    try:
+        sys.exit(main(json_format=args.json))
+    except Exception as e:
+        sys.stderr.write(traceback.format_exc())
+        sys.exit(1)


### PR DESCRIPTION
This pull request makes changes to the underlying script behind `make safety` to more easily share what vulnerabilities are being ignored.

To this end, I've converted the check into a python script.  This lets us store the information about what to ignore in a JSON file.

The script will run `safety` (the command line vulnerability checker) on all requirements.txt files.  The safety command will be instructed to ignore the appropriate vulnerabilities in `project.json` in the root directory of this repository. If vulnerabilities are found, the script will exit with a nonzero code. 