### PR TITLE
If required env vars are not supplied to django-start.sh, fail

### DIFF
--- a/devops/docker/django-start.sh
+++ b/devops/docker/django-start.sh
@@ -16,7 +16,7 @@ wait_for_node() {
 
 wait_for_postgres() {
     echo "Waiting for postgres to start..."
-    until nc -z "${DJANGO_DB_HOST}" "${DJANGO_DB_PORT}"
+    until nc -z "${DJANGO_DB_HOST?}" "${DJANGO_DB_PORT?}"
     do
         sleep 2
     done
@@ -31,7 +31,7 @@ django_start() {
         ./devops/scripts/version-file.sh
         ./manage.py runserver 0.0.0.0:8000
     else
-        gunicorn -c /etc/gunicorn/gunicorn.py "${DJANGO_APP_NAME}.wsgi"
+        gunicorn -c /etc/gunicorn/gunicorn.py "${DJANGO_APP_NAME?}.wsgi"
     fi
 }
 


### PR DESCRIPTION
While debugging something, I tried to start the app without `DJANGO_APP_NAME` exported and ran into a cryptic error about importing `.wsgi`. Currently, if that variable is unset, the script will run `gunicorn` but pass in an incorrect module name (which I think `__import__` tries to find as a relative import).

To print an error instead of trying to start the app, this uses the shell feature of failing a command if the interpolated variable is missing (which will cause the script to exit since `set -e` is in use).