### PR TITLE
Add panel for organization URL field

### DIFF
--- a/directory/models/entry.py
+++ b/directory/models/entry.py
@@ -220,6 +220,7 @@ class DirectoryEntry(MetadataPageMixin, Page):
         FieldPanel('landing_page_url'),
         FieldPanel('onion_address'),
         FieldPanel('organization_description'),
+        FieldPanel('organization_url'),
         MultiFieldPanel([
             ImageChooserPanel('organization_logo'),
             ImageChooserPanel('organization_logo_square'),


### PR DESCRIPTION
This pull request adds a panel in the admin for managing the organization URL field on directory entries. It is something that was overlooked in #722 

Refs #675 