### PR TITLE
Scan results in directory API

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -200,9 +200,9 @@ factory-boy==2.9.2 \
     --hash=sha256:340c602f6fed2d8dd160397f28f2c0219e937f0488460450e8e5bf2add020ed6 \
     --hash=sha256:b8334bcc3c5b10af9a83ab5b8786f98cb322638dc1e6d320cad01c7f2b420e87 \
     # via -r requirements.txt, wagtail-factories
-faker==4.0.2 \
-    --hash=sha256:2d3f866ef25e1a5af80e7b0ceeacc3c92dec5d0fdbad3e2cb6adf6e60b22188f \
-    --hash=sha256:b89aa33837498498e15c709eb40c31386408a901a53c7a5e12a425737a767976 \
+faker==4.14.0 \
+    --hash=sha256:30afa8f564350770373f299d2d267bff42aaba699a7ae0a3b6f378b2a8170569 \
+    --hash=sha256:a7a36c3c657f06bd1e3e3821b9480f2a92017d8a26e150e464ab6b97743cbc92 \
     # via -r requirements.txt, factory-boy
 feedparser==5.2.1 \
     --hash=sha256:bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9 \

--- a/directory/api/serializers.py
+++ b/directory/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from wagtail.images.api.fields import ImageRenditionField
 
-from directory.models.entry import DirectoryEntry
+from directory.models.entry import DirectoryEntry, ScanResult
 
 
 class DirectoryEntrySerializer(serializers.ModelSerializer):
@@ -22,6 +22,7 @@ class DirectoryEntrySerializer(serializers.ModelSerializer):
         read_only=True,
         many=True
     )
+    latest_scan = serializers.SerializerMethodField()
 
     class Meta:
         model = DirectoryEntry
@@ -38,4 +39,23 @@ class DirectoryEntrySerializer(serializers.ModelSerializer):
             'languages',
             'topics',
             'countries',
+            'latest_scan',
         ]
+
+    def get_latest_scan(self, directory_entry):
+        latest = directory_entry.get_live_result()
+
+        if latest:
+            serializer_latest = ScanResultSerializer(instance=latest)
+            return serializer_latest.data
+
+
+class ScanResultSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ScanResult
+        exclude = (
+            'securedrop',
+            'id',
+            'cross_domain_asset_summary',
+            'ignored_cross_domain_assets',
+        )

--- a/directory/tests/factories/entry.py
+++ b/directory/tests/factories/entry.py
@@ -79,14 +79,16 @@ class DirectoryEntryFactory(wagtail_factories.PageFactory):
             self._prefetched_objects_cache = {'topics': topics}
 
 
-class ScanResultFactory(factory.Factory):
+class ScanResultFactory(factory.DjangoModelFactory):
     class Meta:
         model = ScanResult
+
+    result_last_seen = factory.LazyFunction(datetime.utcnow)
+    live = False
 
     class Params:
         no_failures = factory.Trait(
             live=True,
-            result_last_seen=datetime.today(),
             forces_https=True,
             hsts=True,
             hsts_max_age=True,
@@ -118,6 +120,7 @@ class ScanResultFactory(factory.Factory):
             no_analytics=True,
             subdomain=False,
             no_cookies=True,
+            http2=True,
         )
         moderate_warning = factory.Trait(
             no_failures=True,

--- a/directory/tests/factories/taxonomy.py
+++ b/directory/tests/factories/taxonomy.py
@@ -7,19 +7,30 @@ class LanguageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Language
         django_get_or_create = ('title',)
-    # there were not suffient random words in faker, so we're using sentences
-    title = factory.Faker('sentence', nb_words=3)
+    title = factory.Faker('language_name')
 
 
 class CountryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Country
         django_get_or_create = ('title',)
-    title = factory.Faker('sentence', nb_words=3)
+    title = factory.Faker('country')
 
 
 class TopicFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Topic
         django_get_or_create = ('title',)
-    title = factory.Faker('sentence', nb_words=3)
+    title = factory.Iterator([
+        'Algebra',
+        'Applied Mathematics',
+        'Calculus and Analysis',
+        'Discrete Mathematics',
+        'Foundations of Mathematics',
+        'Geometry',
+        'History and Terminology',
+        'Number Theory',
+        'Probability and Statistics',
+        'Recreational Mathematics',
+        'Topology',
+    ])

--- a/directory/tests/test_api.py
+++ b/directory/tests/test_api.py
@@ -5,6 +5,7 @@ from wagtail.core.models import Site
 from directory.tests.factories import (
     DirectoryPageFactory,
     DirectoryEntryFactory,
+    ScanResultFactory,
 )
 
 
@@ -37,4 +38,69 @@ class ApiTestCase(TestCase):
             'countries': [country.title for country in self.entry.countries.all()],
             'topics': [topic.title for topic in self.entry.topics.all()],
             'languages': [lang.title for lang in self.entry.languages.all()],
+            'latest_scan': None,
+        })
+
+
+class ApiLatestScanResultTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.directory = DirectoryPageFactory(
+            parent=Site.objects.get().root_page,
+        )
+        cls.entry = DirectoryEntryFactory(parent=cls.directory)
+
+        cls.scan_fail = ScanResultFactory(
+            landing_page_url=cls.entry.landing_page_url,
+            severe_warning=True,
+            securedrop=cls.entry,
+        )
+        cls.scan_pass = ScanResultFactory(
+            landing_page_url=cls.entry.landing_page_url,
+            no_failures=True,
+            securedrop=cls.entry,
+        )
+
+    def test_scan_result_data_is_correct(self):
+        response = self.client.get(reverse('directoryentry-list'), format='json')
+        # The diffs for the dict in this test can be quite large
+        self.maxDiff = 1500
+        self.assertEqual(dict(response.data[0]['latest_scan']), {
+            'live': True,
+            'landing_page_url': self.entry.landing_page_url,
+            'result_last_seen': self.scan_pass.result_last_seen.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'forces_https': True,
+            'hsts': True,
+            'hsts_max_age': True,
+            'hsts_entire_domain': True,
+            'hsts_preloaded': True,
+            'http_status_200_ok': True,
+            'no_cross_domain_redirects': True,
+            'no_cross_domain_assets': True,
+            'expected_encoding': True,
+            'no_server_info': True,
+            'no_server_version': True,
+            'csp_origin_only': True,
+            'mime_sniffing_blocked': True,
+            'noopen_download': True,
+            'xss_protection': True,
+            'clickjacking_protection': True,
+            'good_cross_domain_policy': True,
+            'http_1_0_caching_disabled': True,
+            'cache_control_set': True,
+            'cache_control_revalidate_set': True,
+            'cache_control_nocache_set': True,
+            'cache_control_notransform_set': True,
+            'cache_control_nostore_set': True,
+            'cache_control_private_set': True,
+            'expires_set': True,
+            'referrer_policy_set_to_no_referrer': True,
+            'safe_onion_address': True,
+            'no_cdn': True,
+            'no_analytics': True,
+            'subdomain': False,
+            'no_cookies': True,
+            'http2': True,
+            'redirect_target': None,
+            'grade': 'A',
         })

--- a/directory/tests/test_api.py
+++ b/directory/tests/test_api.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.core.models import Site
+
+from directory.tests.factories import (
+    DirectoryPageFactory,
+    DirectoryEntryFactory,
+)
+
+
+class ApiTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.directory = DirectoryPageFactory(
+            parent=Site.objects.get().root_page,
+        )
+        cls.entry = DirectoryEntryFactory(parent=cls.directory)
+
+    def test_directory_is_at_api_root(self):
+        response = self.client.get(reverse('api-root'), format='json')
+
+        self.assertIn('directory', response.data)
+
+    def test_directory_entry_data_is_correct(self):
+        response = self.client.get(reverse('directoryentry-list'), format='json')
+
+        self.assertEqual(dict(response.data[0]), {
+            'title': self.entry.title,
+            'slug': self.entry.slug,
+            'directory_url': self.entry.full_url,
+            'first_published_at': self.entry.first_published_at,
+            'landing_page_url': self.entry.landing_page_url,
+            'onion_address': self.entry.onion_address,
+            'organization_logo': self.entry.organization_logo,
+            'organization_description': self.entry.organization_description,
+            'organization_url': self.entry.organization_url,
+            'countries': [country.title for country in self.entry.countries.all()],
+            'topics': [topic.title for topic in self.entry.topics.all()],
+            'languages': [lang.title for lang in self.entry.languages.all()],
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,9 +155,9 @@ factory-boy==2.9.2 \
     --hash=sha256:340c602f6fed2d8dd160397f28f2c0219e937f0488460450e8e5bf2add020ed6 \
     --hash=sha256:b8334bcc3c5b10af9a83ab5b8786f98cb322638dc1e6d320cad01c7f2b420e87 \
     # via -r requirements.in, wagtail-factories
-faker==4.0.2 \
-    --hash=sha256:2d3f866ef25e1a5af80e7b0ceeacc3c92dec5d0fdbad3e2cb6adf6e60b22188f \
-    --hash=sha256:b89aa33837498498e15c709eb40c31386408a901a53c7a5e12a425737a767976 \
+faker==4.14.0 \
+    --hash=sha256:30afa8f564350770373f299d2d267bff42aaba699a7ae0a3b6f378b2a8170569 \
+    --hash=sha256:a7a36c3c657f06bd1e3e3821b9480f2a92017d8a26e150e464ab6b97743cbc92 \
     # via factory-boy
 feedparser==5.2.1 \
     --hash=sha256:bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9 \


### PR DESCRIPTION
This pull request adds a `latest_scan` field to entries in the directory API. This field contains the complete information for the most recent scan result for that directory. I've also included some minor updates to some related test factories.

To test this, you can load the url http://localhost:8000/api/v1/directory/ in a browser or with a tool like `curl`. 

![image](https://user-images.githubusercontent.com/561931/97490545-626ae380-1937-11eb-9d2b-aef7d35cdc50.png)

Fixes #734 