### PR TITLE
Remove settings related to HSTS, which is handled by nginx in production

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -129,10 +129,6 @@ SECURE_BROWSER_XSS_FILTER = True
 # Set X-Content-Type-Options
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
-# Adjust HSTS
-SECURE_HSTS_SECONDS = 63072000
-SECURE_HSTS_PRELOAD = True
-
 # Make the deployment's onion service name available to templates
 SECUREDROP_ONION_HOSTNAME = os.environ.get('DJANGO_ONION_HOSTNAME')
 


### PR DESCRIPTION
Since we have made HSTS be handled at the ingress-nginx level for consistency, these settings can be removed.