### PR TITLE
HTTPS analytics

### DIFF
--- a/common/context_processors.py
+++ b/common/context_processors.py
@@ -1,8 +1,0 @@
-from django.conf import settings
-
-
-def analytics_variables(request):
-    return {
-        'PIWIK_DOMAIN_PATH': settings.PIWIK_DOMAIN_PATH,
-        'PIWIK_SITE_ID': settings.PIWIK_SITE_ID,
-    }

--- a/common/context_processors.py
+++ b/common/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def analytics_variables(request):
+    return {
+        'PIWIK_DOMAIN_PATH': settings.PIWIK_DOMAIN_PATH,
+        'PIWIK_SITE_ID': settings.PIWIK_SITE_ID,
+    }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -145,9 +145,9 @@ django-analytical==2.4.0 \
 django-anymail[mailgun]==1.4 \
     --hash=sha256:f534ab2ca82b6e1155d02d656db28d17d1f4e832f641b537539a4ebbcdee7e39 \
     # via -r requirements.txt
-django-csp==3.4 \
-    --hash=sha256:04c0ccd4e1339e8f6af48c55c3347dc996fde2d22d79e8bf2f6b7a920412e408 \
-    --hash=sha256:096b634430d8ea81c3d9f216f87be890f3a975c17bb9a4631f6a1619ac09c91e \
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727 \
     # via -r requirements.txt
 django-debug-toolbar==1.9.1 \
     --hash=sha256:4af2a4e1e932dadbda197b18585962d4fc20172b4e5a479490bc659fe998864d \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -138,10 +138,6 @@ django-allauth-2fa==0.6 \
 django-allauth==0.41.0 \
     --hash=sha256:7ab91485b80d231da191d5c7999ba93170ef1bf14ab6487d886598a1ad03e1d8 \
     # via -r requirements.txt, django-allauth-2fa
-django-analytical==2.4.0 \
-    --hash=sha256:44dd65e30a3f11519852d5f5e50556c0f88cabb5720a2fd3637621952048abef \
-    --hash=sha256:cf7b4c0b368139a090da2b0b45741bdd28b54daa0cb2b83ef801021c8eb2c050 \
-    # via -r requirements.txt
 django-anymail[mailgun]==1.4 \
     --hash=sha256:f534ab2ca82b6e1155d02d656db28d17d1f4e832f641b537539a4ebbcdee7e39 \
     # via -r requirements.txt
@@ -185,7 +181,7 @@ django-webpack-loader==0.5.0 \
 django==2.2.14 \
     --hash=sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191 \
     --hash=sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8 \
-    # via -r requirements.txt, django-allauth, django-allauth-2fa, django-analytical, django-anymail, django-csp, django-debug-toolbar, django-logging-json, django-otp, django-settings-export, django-storages, django-taggit, django-treebeard, djangorestframework, wagtail
+    # via -r requirements.txt, django-allauth, django-allauth-2fa, django-anymail, django-csp, django-debug-toolbar, django-logging-json, django-otp, django-settings-export, django-storages, django-taggit, django-treebeard, djangorestframework, wagtail
 djangorestframework==3.12.1 \
     --hash=sha256:5c5071fcbad6dce16f566d492015c829ddb0df42965d488b878594aabc3aed21 \
     --hash=sha256:d54452aedebb4b650254ca092f9f4f5df947cb1de6ab245d817b08b4f4156249 \

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ wagtail-autocomplete
 unittest-xml-reporting
 django-allauth>=0.41
 django-allauth-2fa
-django-csp
+django-csp>=3.7
 zxcvbn-python
 requests>=2.20.0
 urllib3>1.25.7

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 https://github.com/freedomofpress/django-logging/zipball/b7d0b7b542db6ac088dbf3d2e7b249df333d3082
 bleach>=3.1.3
 Django>=2.2.11,<2.3
-django-analytical>=2.4
 django-anymail[mailgun]>=1.4
 django-modelcluster
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,10 +97,6 @@ django-allauth-2fa==0.6 \
 django-allauth==0.41.0 \
     --hash=sha256:7ab91485b80d231da191d5c7999ba93170ef1bf14ab6487d886598a1ad03e1d8 \
     # via -r requirements.in, django-allauth-2fa
-django-analytical==2.4.0 \
-    --hash=sha256:44dd65e30a3f11519852d5f5e50556c0f88cabb5720a2fd3637621952048abef \
-    --hash=sha256:cf7b4c0b368139a090da2b0b45741bdd28b54daa0cb2b83ef801021c8eb2c050 \
-    # via -r requirements.in
 django-anymail[mailgun]==1.4 \
     --hash=sha256:f534ab2ca82b6e1155d02d656db28d17d1f4e832f641b537539a4ebbcdee7e39 \
     # via -r requirements.in
@@ -140,7 +136,7 @@ django-webpack-loader==0.5.0 \
 django==2.2.14 \
     --hash=sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191 \
     --hash=sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8 \
-    # via -r requirements.in, django-allauth, django-allauth-2fa, django-analytical, django-anymail, django-csp, django-logging-json, django-otp, django-settings-export, django-storages, django-taggit, django-treebeard, djangorestframework, wagtail
+    # via -r requirements.in, django-allauth, django-allauth-2fa, django-anymail, django-csp, django-logging-json, django-otp, django-settings-export, django-storages, django-taggit, django-treebeard, djangorestframework, wagtail
 djangorestframework==3.12.1 \
     --hash=sha256:5c5071fcbad6dce16f566d492015c829ddb0df42965d488b878594aabc3aed21 \
     --hash=sha256:d54452aedebb4b650254ca092f9f4f5df947cb1de6ab245d817b08b4f4156249 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,9 +104,9 @@ django-analytical==2.4.0 \
 django-anymail[mailgun]==1.4 \
     --hash=sha256:f534ab2ca82b6e1155d02d656db28d17d1f4e832f641b537539a4ebbcdee7e39 \
     # via -r requirements.in
-django-csp==3.4 \
-    --hash=sha256:04c0ccd4e1339e8f6af48c55c3347dc996fde2d22d79e8bf2f6b7a920412e408 \
-    --hash=sha256:096b634430d8ea81c3d9f216f87be890f3a975c17bb9a4631f6a1619ac09c91e \
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727 \
     # via -r requirements.in
 https://github.com/freedomofpress/django-logging/zipball/b7d0b7b542db6ac088dbf3d2e7b249df333d3082 \
     --hash=sha256:7a9857fff2988572ee03ae0ea2dc17e389095663ff72e2ea3fad904a4023b0f4 \

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
     'wagtailautocomplete',
     'webpack_loader',
     'taggit',
-    'csp',
     'rest_framework',
     'wagtailmedia',
 
@@ -254,15 +253,12 @@ WEBPACK_LOADER = {
     }
 }
 
-
 # Disable analytics by default
-PIWIK_DOMAIN_PATH = None
-PIWIK_SITE_ID = None
+ANALYTICS_ENABLED = False
 
 # Export analytics settings for use in site templates
 SETTINGS_EXPORT = [
-    'PIWIK_SITE_ID',
-    'PIWIK_DOMAIN_PATH',
+    'ANALYTICS_ENABLED',
 ]
 # Prevent template variable name collision with wagtail settings
 SETTINGS_EXPORT_VARIABLE_NAME = 'django_settings'
@@ -413,9 +409,6 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-eval'",
     "analytics.freedom.press",
-)
-CSP_INCLUDE_NONCE_IN = (
-    'script-src',
 )
 CSP_STYLE_SRC = (
     "'self'",

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -150,7 +150,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'django_settings_export.settings_export',
                 'wagtail.contrib.settings.context_processors.settings',
-                'common.context_processors.analytics_variables',
             ],
         },
     },
@@ -255,18 +254,18 @@ WEBPACK_LOADER = {
     }
 }
 
-# Sadly, we have to set these to real-looking (but invalid) values, or
-# django-analytical will raise AnalyticalException. It would be preferable to be
-# able to set these to None (or not be required to set them at all, which the
-# django-analytical docs incorrectly suggest is possible).
-PIWIK_DOMAIN_PATH = 'analytics.example.com'
-# Piwik Site ID's start at 1, so 0 is an invalid ID which can be used to
-# indicate to the template that the Piwik tracking code should not be rendered.
-PIWIK_SITE_ID = '0'
 
+# Disable analytics by default
+PIWIK_DOMAIN_PATH = None
+PIWIK_SITE_ID = None
+
+# Export analytics settings for use in site templates
 SETTINGS_EXPORT = [
     'PIWIK_SITE_ID',
+    'PIWIK_DOMAIN_PATH',
 ]
+# Prevent template variable name collision with wagtail settings
+SETTINGS_EXPORT_VARIABLE_NAME = 'django_settings'
 
 # django-taggit
 TAGGIT_CASE_INSENSITIVE = True

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     'webpack_loader',
     'taggit',
     'analytical',
+    'csp',
     'rest_framework',
     'wagtailmedia',
 
@@ -149,7 +150,8 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django_settings_export.settings_export',
-                'wagtail.contrib.settings.context_processors.settings'
+                'wagtail.contrib.settings.context_processors.settings',
+                'common.context_processors.analytics_variables',
             ],
         },
     },
@@ -412,9 +414,10 @@ CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-eval'",
-    # Piwik/Matomo analytics inline code:
-    "'sha256-Ujy9USzNCsaDKHVACggM1NqXbQJ2ljlpMX9U4g2d5d0='",
     "analytics.freedom.press",
+)
+CSP_INCLUDE_NONCE_IN = (
+    'script-src',
 )
 CSP_STYLE_SRC = (
     "'self'",

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
     'wagtailautocomplete',
     'webpack_loader',
     'taggit',
-    'analytical',
     'csp',
     'rest_framework',
     'wagtailmedia',

--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -116,12 +116,6 @@ if os.environ.get('CLOUDFLARE_TOKEN') and os.environ.get('CLOUDFLARE_EMAIL'):
 if os.environ.get('PIWIK_DOMAIN_PATH'):
     PIWIK_DOMAIN_PATH = os.environ.get('PIWIK_DOMAIN_PATH')
     PIWIK_SITE_ID = os.environ.get('PIWIK_SITE_ID', '5')
-    # Disable auto-identify because
-    # 1. we have a very small number of visitors who will be logged in and they
-    #    are all FPF staff and
-    # 2. auto-identify adjusts inline analytics code causing it to fail our
-    #    content security policy
-    ANALYTICAL_AUTO_IDENTIFY = False
 
 # Mailgun integration
 #

--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -113,9 +113,7 @@ if os.environ.get('CLOUDFLARE_TOKEN') and os.environ.get('CLOUDFLARE_EMAIL'):
 
 # Piwik integration for analytics
 #
-if os.environ.get('PIWIK_DOMAIN_PATH'):
-    PIWIK_DOMAIN_PATH = os.environ.get('PIWIK_DOMAIN_PATH')
-    PIWIK_SITE_ID = os.environ.get('PIWIK_SITE_ID', '5')
+ANALYTICS_ENABLED = True
 
 # Mailgun integration
 #

--- a/securedrop/static/js/piwik.js
+++ b/securedrop/static/js/piwik.js
@@ -1,0 +1,9 @@
+var idSite = 3;
+var piwikTrackingApiUrl = 'https://analytics.freedom.press/piwik.php';
+
+var _paq = window._paq = window._paq || [];
+
+_paq.push(['setTrackerUrl', piwikTrackingApiUrl]);
+_paq.push(['setSiteId', idSite]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);

--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -50,22 +50,24 @@
 	<body class="{% block body_class %}{% endblock %}">
 		{% block body %}
 		{% endblock %}
-		{% script type="application/javascript" async=False %}
-		<script type="text/javascript">
-			var _paq = _paq || [];
+		{% if django_settings.PIWIK_DOMAIN_PATH and django_settings.PIWIK_SITE_ID %}
+			{% script type="application/javascript" async=False %}
+			<script type="text/javascript">
+			 var _paq = _paq || [];
 
-			_paq.push(['trackPageView']);
-			_paq.push(['enableLinkTracking']);
-			(function() {
-				var u="https://{{ PIWIK_DOMAIN_PATH }}/";
-				_paq.push(['setTrackerUrl', u+'piwik.php']);
-				_paq.push(['setSiteId', {{ PIWIK_SITE_ID }}]);
-				var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-				g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-			})();
-		</script>
+			 _paq.push(['trackPageView']);
+			 _paq.push(['enableLinkTracking']);
+			 (function() {
+				 var u="https://{{ django_settings.PIWIK_DOMAIN_PATH }}/";
+				 _paq.push(['setTrackerUrl', u+'piwik.php']);
+				 _paq.push(['setSiteId', {{ django_settings.PIWIK_SITE_ID }}]);
+				 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+				 g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+			 })();
+			</script>
 		{% endscript %}
-		<noscript><p><img src="https://{{ PIWIK_DOMAIN_PATH }}/piwik.php?idsite={{ PIWIK_SITE_ID }}" style="border:0;" alt="" /></p></noscript>
+		<noscript><p><img src="https://{{ django_settings.PIWIK_DOMAIN_PATH }}/piwik.php?idsite={{ django_settings.PIWIK_SITE_ID }}" style="border:0;" alt="" /></p></noscript>
+		{% endif %}
 	</body>
 
 	{% block js %}

--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -1,4 +1,4 @@
-{% load static wagtailmetadata_tags wagtailsettings_tags common_tags csp %}
+{% load static wagtailmetadata_tags wagtailsettings_tags common_tags %}
 {% load render_bundle from webpack_loader %}
 
 <!DOCTYPE html>
@@ -50,23 +50,11 @@
 	<body class="{% block body_class %}{% endblock %}">
 		{% block body %}
 		{% endblock %}
-		{% if django_settings.PIWIK_DOMAIN_PATH and django_settings.PIWIK_SITE_ID %}
-			{% script type="application/javascript" async=False %}
-			<script type="text/javascript">
-			 var _paq = _paq || [];
 
-			 _paq.push(['trackPageView']);
-			 _paq.push(['enableLinkTracking']);
-			 (function() {
-				 var u="https://{{ django_settings.PIWIK_DOMAIN_PATH }}/";
-				 _paq.push(['setTrackerUrl', u+'piwik.php']);
-				 _paq.push(['setSiteId', {{ django_settings.PIWIK_SITE_ID }}]);
-				 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-				 g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-			 })();
-			</script>
-		{% endscript %}
-		<noscript><p><img src="https://{{ django_settings.PIWIK_DOMAIN_PATH }}/piwik.php?idsite={{ django_settings.PIWIK_SITE_ID }}" style="border:0;" alt="" /></p></noscript>
+		{% if django_settings.ANALYTICS_ENABLED %}
+			<script src="https://analytics.freedom.press/piwik.js" async defer></script>
+			<script type="text/javascript" src="{% static 'js/piwik.js' %}"></script>
+			<noscript><p><img src="https://analytics.freedom.press/piwik.php?idsite=3" style="border:0;" alt="" /></p></noscript>
 		{% endif %}
 	</body>
 

--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -1,4 +1,4 @@
-{% load static wagtailmetadata_tags wagtailsettings_tags common_tags piwik %}
+{% load static wagtailmetadata_tags wagtailsettings_tags common_tags csp %}
 {% load render_bundle from webpack_loader %}
 
 <!DOCTYPE html>
@@ -50,7 +50,22 @@
 	<body class="{% block body_class %}{% endblock %}">
 		{% block body %}
 		{% endblock %}
-		{% piwik %}
+		{% script type="application/javascript" async=False %}
+		<script type="text/javascript">
+			var _paq = _paq || [];
+
+			_paq.push(['trackPageView']);
+			_paq.push(['enableLinkTracking']);
+			(function() {
+				var u="https://{{ PIWIK_DOMAIN_PATH }}/";
+				_paq.push(['setTrackerUrl', u+'piwik.php']);
+				_paq.push(['setSiteId', {{ PIWIK_SITE_ID }}]);
+				var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+				g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+			})();
+		</script>
+		{% endscript %}
+		<noscript><p><img src="https://{{ PIWIK_DOMAIN_PATH }}/piwik.php?idsite={{ PIWIK_SITE_ID }}" style="border:0;" alt="" /></p></noscript>
 	</body>
 
 	{% block js %}


### PR DESCRIPTION
This pull request replaces the use of `django-analytical` with our own code to insert the Piwik analytics javascript snippet with the appropriate variables customized. This change enables us to force the use of HTTPS when communicating with the analytics server.

Another change of note: now we can use a nonce (rather than a sha256 hash) on this code to allow it to pass the CSP.

Fixes #754 