### PR TITLE
Should fix analytics JS code ordering

### DIFF
--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -52,8 +52,8 @@
 		{% endblock %}
 
 		{% if django_settings.ANALYTICS_ENABLED %}
-			<script src="https://analytics.freedom.press/piwik.js" async defer></script>
 			<script type="text/javascript" src="{% static 'js/piwik.js' %}"></script>
+			<script src="https://analytics.freedom.press/piwik.js" async defer></script>
 			<noscript><p><img src="https://analytics.freedom.press/piwik.php?idsite=3" style="border:0;" alt="" /></p></noscript>
 		{% endif %}
 	</body>


### PR DESCRIPTION
Should fix #772 

Based on the error and the docs, I think the reordering should do the trick. The `async` should not affect because the previous script isn't `async` so that script will need to be loaded, and only `https://analytics.freedom.press/piwik.js` will load asynchronously which should be fine.