### PR TITLE
Model admin for scan results

### DIFF
--- a/directory/models/entry.py
+++ b/directory/models/entry.py
@@ -12,6 +12,7 @@ from wagtail.admin.edit_handlers import (
     FieldPanel,
     InlinePanel,
     MultiFieldPanel,
+    HelpPanel,
 )
 from wagtail.admin import messages
 from wagtail.images.edit_handlers import ImageChooserPanel
@@ -231,6 +232,7 @@ class DirectoryEntry(MetadataPageMixin, Page):
         AutocompletePanel('countries', 'directory.Country', is_single=False),
         AutocompletePanel('topics', 'directory.Topic', is_single=False),
         InlinePanel('owners', label='Owners'),
+        HelpPanel(heading='Scans', template='directory/admin_scan_result_help.html')
     ]
 
     settings_panels = Page.settings_panels + [

--- a/directory/models/entry.py
+++ b/directory/models/entry.py
@@ -231,7 +231,6 @@ class DirectoryEntry(MetadataPageMixin, Page):
         AutocompletePanel('countries', 'directory.Country', is_single=False),
         AutocompletePanel('topics', 'directory.Topic', is_single=False),
         InlinePanel('owners', label='Owners'),
-        InlinePanel('results', label='Results'),
     ]
 
     settings_panels = Page.settings_panels + [

--- a/directory/templates/directory/admin_scan_result_help.html
+++ b/directory/templates/directory/admin_scan_result_help.html
@@ -1,0 +1,23 @@
+<fieldset>
+    {% if self.heading %}
+        <legend>{{ self.heading }}</legend>
+    {% endif %}
+    <div class="{{ self.classname }}">
+		{% with latest=self.instance.get_live_result %}
+			<a class="button button-small button-secondary" href="{% url 'directory_scanresult_modeladmin_inspect' instance_pk=latest.pk %}">
+				Latest live result
+			</a>
+			<dl>
+				<dt>Grade</dt>
+				<dd>{{ latest.grade }}</dd>
+
+				<dt>Result date</dt>
+				<dd>{{ latest.result_last_seen }}</dd>
+			</dl>
+		{% endwith %}
+
+		<hr>
+
+		<a class="button button-small button-secondary" href="{% url 'directory_scanresult_modeladmin_index' %}?securedrop__page_ptr_id__exact={{ self.instance.pk }}">All scan results</a>
+	</div>
+</fieldset>

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -68,7 +68,7 @@ def add_scan_results_buttons(page, page_perms, is_parent=False):
 @hooks.register('add_scan_results_button')
 def add_bundle_stats_button(page, page_perms, is_parent=False):
     index_url = scanresult_modeladmin.url_helper.get_action_url('index')
-    results_url = index_url + '?securedrop__page_ptr_id__exact=' + str(page.pk)
+    results_url = f'{index_url}?securedrop__page_ptr_id__exact={page.pk}'
     latest = page.get_live_result()
     return [
         Button(

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -31,6 +31,7 @@ class ReadOnlyPermissionHelper(PermissionHelper):
 
 
 class ScanResultAdmin(ModelAdmin):
+    """ModelAdmin for viewing/searching ScanResults."""
     model = ScanResult
     menu_icon = 'folder-open-inverse'
     menu_order = 500
@@ -40,7 +41,7 @@ class ScanResultAdmin(ModelAdmin):
         'grade',
         'live',
     )
-    search_fields = ('landing_page_url',)
+    search_fields = ('landing_page_url', 'securedrop__title')
     permission_helper_class = ReadOnlyPermissionHelper
     inspect_view_enabled = True
 
@@ -67,6 +68,12 @@ def add_scan_results_buttons(page, page_perms, is_parent=False):
 
 @hooks.register('add_scan_results_button')
 def add_bundle_stats_button(page, page_perms, is_parent=False):
+    """Creates drop-down buttons that link to ScanResult model admin
+    sections for a given DirectoryEntry on the page listing area.  The
+    links go to the most recent live result, as well as the filtered
+    list of all results.
+
+    """
     index_url = scanresult_modeladmin.url_helper.get_action_url('index')
     results_url = f'{index_url}?securedrop__page_ptr_id__exact={page.pk}'
     latest = page.get_live_result()

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -1,0 +1,87 @@
+from wagtail.admin.widgets import (
+    ButtonWithDropdownFromHook,
+    Button,
+)
+from wagtail.contrib.modeladmin.helpers import PermissionHelper
+from wagtail.contrib.modeladmin.options import (
+    ModelAdmin,
+    modeladmin_register,
+)
+from wagtail.core import hooks
+
+from .models import ScanResult, DirectoryEntry
+
+
+class ReadOnlyPermissionHelper(PermissionHelper):
+    """Permission helper for read-only ModelAdmins
+    Permission helper class that denies all permissions to modify,
+    delete, or create objects.
+    """
+    def user_can_list(self, user):
+        return True
+
+    def user_can_create(self, user):
+        return False
+
+    def user_can_edit_obj(self, user, obj):
+        return False
+
+    def user_can_delete_obj(self, user, obj):
+        return False
+
+
+class ScanResultAdmin(ModelAdmin):
+    model = ScanResult
+    menu_icon = 'folder-open-inverse'
+    menu_order = 500
+    list_display = ('securedrop', 'result_last_seen', 'live', 'grade')
+    list_filter = (
+        'result_last_seen',
+        'grade',
+        'live',
+    )
+    search_fields = ('landing_page_url',)
+    permission_helper_class = ReadOnlyPermissionHelper
+    inspect_view_enabled = True
+
+
+scanresult_modeladmin = ScanResultAdmin()
+
+
+@hooks.register('register_page_listing_buttons')
+def add_scan_results_buttons(page, page_perms, is_parent=False):
+    """
+    For directory entry pages, add an additional button to the page listing,
+    linking to the most relevant model admin pages for scan results.
+    """
+    if isinstance(page, DirectoryEntry):
+        yield ButtonWithDropdownFromHook(
+            'Scan Results',
+            hook_name='add_scan_results_button',
+            page=page,
+            page_perms=page_perms,
+            is_parent=is_parent,
+            priority=35
+        )
+
+
+@hooks.register('add_scan_results_button')
+def add_bundle_stats_button(page, page_perms, is_parent=False):
+    index_url = scanresult_modeladmin.url_helper.get_action_url('index')
+    results_url = index_url + '?securedrop__page_ptr_id__exact=' + str(page.pk)
+    latest = page.get_live_result()
+    return [
+        Button(
+            'All Results',
+            results_url,
+            priority=10,
+        ),
+        Button(
+            'Latest Result',
+            scanresult_modeladmin.url_helper.get_action_url('inspect', latest.pk),
+            priority=20,
+        )
+    ]
+
+
+modeladmin_register(ScanResultAdmin)


### PR DESCRIPTION
This pull request replaces the inline view of scan results that appears on the directory entry admin page with a separate Model Admin area. The reason for this is the inline scan result list becomes slow if there are a large number of results, and also can potentially break the edit functionality.

Instead of that, I've added a drop down button on the page listing for directory entries:

![image](https://user-images.githubusercontent.com/561931/101408025-c0c9a100-38a9-11eb-90f9-5e3515aaa3ee.png)

Fixes #777 