### PR TITLE
Adds word break to onion address

### DIFF
--- a/client/common/sass/directory/_instance-instructions.sass
+++ b/client/common/sass/directory/_instance-instructions.sass
@@ -4,6 +4,7 @@
 		font-weight: $sans-bold
 
 	&__onion-address
+		word-break: break-word
 		background-color: #e6e6e6
 		font-family: $mono
 		border-radius: 3px


### PR DESCRIPTION
Fixes #792 
Adds word break to onion address so that directory listing with v3 onion address don't break the UI in smaller screens.