### PR TITLE
Fix button rendering bug in directory entry admin listing

### DIFF
--- a/directory/tests/test_filters.py
+++ b/directory/tests/test_filters.py
@@ -224,7 +224,11 @@ class DirectoryMultipleFiltersTest(TestCase):
         self.az_pf_instance.topics.add(pf)
         self.az_pf_instance.save()
 
-        self.other_instance = DirectoryEntryFactory(parent=self.directory)
+        self.other_instance = DirectoryEntryFactory(
+            parent=self.directory,
+            languages=0,
+            countries=0,
+        )
         self.other_instance.languages.add(spanish)
         self.other_instance.topics.add(pf)
         self.other_instance.save()

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -76,19 +76,23 @@ def add_bundle_stats_button(page, page_perms, is_parent=False):
     """
     index_url = scanresult_modeladmin.url_helper.get_action_url('index')
     results_url = f'{index_url}?securedrop__page_ptr_id__exact={page.pk}'
-    latest = page.get_live_result()
-    return [
+    buttons = [
         Button(
             'All Results',
             results_url,
             priority=10,
-        ),
-        Button(
-            'Latest Result',
-            scanresult_modeladmin.url_helper.get_action_url('inspect', latest.pk),
-            priority=20,
         )
     ]
+    latest = page.get_live_result()
+    if latest and latest.pk:
+        buttons.append(
+            Button(
+                'Latest Result',
+                scanresult_modeladmin.url_helper.get_action_url('inspect', latest.pk),
+                priority=20,
+            )
+        )
+    return buttons
 
 
 modeladmin_register(ScanResultAdmin)

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
 	"variables": {
-		"SAFETY_IGNORE_IDS": ["38197", "38932"]
+		"SAFETY_IGNORE_IDS": ["38197", "38932", "39252"]
 	}
 }


### PR DESCRIPTION
This fixes a bug on the directory entry admin listings where if the latest scan result for a directory entry in the listing does not exist, then the button creation hook would raise an exception and the admin page would not render.  I've fixed it by only adding that button if the latest result actually is present.

I was running into this while doing some testing locally, but I don't see why it wouldn't happen in production eventually, either.