### PR TITLE
Fix rich text rendering visual errors across site

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -58,9 +58,9 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
-    'wagtail.core',
     # See https://docs.wagtail.io/en/stable/reference/contrib/legacy_richtext.html#legacy-richtext
     'wagtail.contrib.legacy.richtext',
+    'wagtail.core',
 
     'allauth',
     'allauth.account',


### PR DESCRIPTION
We rely on wagtail.contrib.legacy.richtext to accomodate our styles
which rely on legacy rich-text rendering, but the contrib needs to
be placed before wagtail.core for legacy rendering to take
precedence. Now it is.