### PR TITLE
Remove "www." prefix from domains before inspecting with pshtt

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -47,7 +47,11 @@ def perform_scan(url: str, permitted_domains: List[str]) -> ScanResult:
     asset_results = parse_assets(assets, [tldextract.extract(page.url).registered_domain] + permitted_domains)
     scan_data.update(asset_results)
 
-    pshtt_results = list(inspect_domains([url_to_domain(page.url)], {'timeout': 10}))
+    pshtt_domain = url_to_domain(page.url)
+    if pshtt_domain.startswith('www.'):
+        pshtt_domain = pshtt_domain[4:]
+
+    pshtt_results = list(inspect_domains([pshtt_domain], {'timeout': 10}))
 
     canonical_url = pshtt_results[0].get('Canonical URL')
     if canonical_url:

--- a/scanner/tests/test_scanner.py
+++ b/scanner/tests/test_scanner.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import re
 from unittest import mock
@@ -433,6 +434,21 @@ class ScannerRedirectionSuccess(TestCase):
         result = scanner.scan(entry)
         self.assertEqual(result.redirect_target, 'https://httpbin.org/status/404')
         self.assertFalse(result.http_status_200_ok)
+
+    @mock.patch('scanner.scanner.tldextract')
+    @mock.patch('scanner.scanner.BeautifulSoup')
+    @mock.patch('scanner.scanner.requests')
+    @mock.patch('scanner.scanner.inspect_domains')
+    def test_scanner_omits_www_prefix_on_domains_domains_for_pshtt(self, mock_inspect_domains, mock_requests, mock_soup, mock_tldextract):
+        entry = DirectoryEntryFactory.create(
+            landing_page_url='https://www.example.com',
+        )
+
+        mock_requests.get.return_value = mock.MagicMock(url=entry.landing_page_url)
+        mock_inspect_domains.return_value = [collections.defaultdict(int)]
+
+        scanner.scan(entry)
+        mock_inspect_domains.assert_called_once_with(['example.com'], {'timeout': 10})
 
 
 class ScannerSubdomainRedirect(TestCase):


### PR DESCRIPTION
Fixes #739

This pull request adds some code to remove, if present, the "www." prefix from any domain name given to pshtt. Pshtt has its own logic to test the www and non-www versions of the domains its given, and it expects to be given the base domain, otherwise it will add "www." on is own, duplicating it if it's already there.