### PR TITLE
Switch pshtt to forked version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,12 +4,6 @@ anyascii==0.1.7 \
     # via
     #   -r requirements.txt
     #   wagtail
-asn1crypto==1.4.0 \
-    --hash=sha256:4bcdf33c861c7d40bdcd74d8e4dd7661aac320fcdf40b9a3f95b4ee12fde2fa8 \
-    --hash=sha256:f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c
-    # via
-    #   -r requirements.txt
-    #   cryptography
 attrs==20.2.0 \
     --hash=sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594 \
     --hash=sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc
@@ -122,26 +116,19 @@ coverage==5.0.3 \
     --hash=sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37 \
     --hash=sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0
     # via -r dev-requirements.in
-cryptography==2.5 \
-    --hash=sha256:05b3ded5e88747d28ee3ef493f2b92cbb947c1e45cf98cfef22e6d38bb67d4af \
-    --hash=sha256:06826e7f72d1770e186e9c90e76b4f84d90cdb917b47ff88d8dc59a7b10e2b1e \
-    --hash=sha256:08b753df3672b7066e74376f42ce8fc4683e4fd1358d34c80f502e939ee944d2 \
-    --hash=sha256:2cd29bd1911782baaee890544c653bb03ec7d95ebeb144d714b0f5c33deb55c7 \
-    --hash=sha256:31e5637e9036d966824edaa91bf0aa39dc6f525a1c599f39fd5c50340264e079 \
-    --hash=sha256:42fad67d7072216a49e34f923d8cbda9edacbf6633b19a79655e88a1b4857063 \
-    --hash=sha256:4946b67235b9d2ea7d31307be9d5ad5959d6c4a8f98f900157b47abddf698401 \
-    --hash=sha256:522fdb2809603ee97a4d0ef2f8d617bc791eb483313ba307cb9c0a773e5e5695 \
-    --hash=sha256:6f841c7272645dd7c65b07b7108adfa8af0aaea57f27b7f59e01d41f75444c85 \
-    --hash=sha256:7d335e35306af5b9bc0560ca39f740dfc8def72749645e193dd35be11fb323b3 \
-    --hash=sha256:8504661ffe324837f5c4607347eeee4cf0fcad689163c6e9c8d3b18cf1f4a4ad \
-    --hash=sha256:9260b201ce584d7825d900c88700aa0bd6b40d4ebac7b213857bd2babee9dbca \
-    --hash=sha256:9a30384cc402eac099210ab9b8801b2ae21e591831253883decdb4513b77a3cd \
-    --hash=sha256:9e29af877c29338f0cab5f049ccc8bd3ead289a557f144376c4fbc7d1b98914f \
-    --hash=sha256:ab50da871bc109b2d9389259aac269dd1b7c7413ee02d06fe4e486ed26882159 \
-    --hash=sha256:b13c80b877e73bcb6f012813c6f4a9334fcf4b0e96681c5a15dac578f2eedfa0 \
-    --hash=sha256:bfe66b577a7118e05b04141f0f1ed0959552d45672aa7ecb3d91e319d846001e \
-    --hash=sha256:e091bd424567efa4b9d94287a952597c05d22155a13716bf5f9f746b9dc906d3 \
-    --hash=sha256:fa2b38c8519c5a3aa6e2b4e1cf1a549b54acda6adb25397ff542068e73d1ed00
+cryptography==3.4.7 \
+    --hash=sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d \
+    --hash=sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959 \
+    --hash=sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6 \
+    --hash=sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873 \
+    --hash=sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2 \
+    --hash=sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713 \
+    --hash=sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1 \
+    --hash=sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177 \
+    --hash=sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250 \
+    --hash=sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca \
+    --hash=sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d \
+    --hash=sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9
     # via
     #   -r requirements.txt
     #   pyopenssl
@@ -479,15 +466,26 @@ multidict==4.7.4 \
     --hash=sha256:dcfed56aa085b89d644af17442cdc2debaa73388feba4b8026446d168ca8dad7 \
     --hash=sha256:f29b885e4903bd57a7789f09fe9d60b6475a6c1a4c0eca874d8558f00f9d4b51
     # via yarl
-nassl==2.2.0 \
-    --hash=sha256:2cad7e728aca58a97c8f6dee2efa3a922e1d5a7090d179cf01ddbb26788e734a \
-    --hash=sha256:2e59f62f8001ef996fdb2ebf242019e5c9d97e269dda43dfe836db0c42fee60a \
-    --hash=sha256:7b48f07e1a7778b8b9ba6ab23db52a0e6e226f6eb5a6ce430b860c020b3cef04 \
-    --hash=sha256:7dd0c5335e787c00c7eb7e20119e7dc132732cbbfe4ee5c6b527501f4bb2c665 \
-    --hash=sha256:860093b431437acf48d34c1823a1e04eb536f8fd3a99fa271b382f1f9c62d899 \
-    --hash=sha256:889f63cb285ba1a8785531c2d6f9cc9a50f6193a83ee2615f4b2b42ccb229fca \
-    --hash=sha256:b19fa8828c86be4e4eced6d7e08982a17d97742f3d721d33bc90d14744173078 \
-    --hash=sha256:bc13593434d90c0a791d1d2d38c286e6d12034ae1c3c23a8b24ced1584b185ad
+nassl==4.0.0 \
+    --hash=sha256:002aa5b3bedde14b3641e6726b76474da8eb1611ff37b32fed1c1011b7a5e31b \
+    --hash=sha256:0550c4c7aeee6611066867af12cc5446a861870fe127ff22a93c8c892f950537 \
+    --hash=sha256:0f0a13be7c2ef64469a789d3797893fb6d2e058f61428d5e1021c78a8deda414 \
+    --hash=sha256:19c26de1f28f90df7bc3ad740b89f39d5e3a218e8105f6543f90960c9805055c \
+    --hash=sha256:2268a426f6c2818ae6d00aece54c5acc86fb65b898c4d33fe95d39980fbd4fe0 \
+    --hash=sha256:39da52cddea977bc2e97b474db5c253d9e1d76d932c9b2648ba457620659ff09 \
+    --hash=sha256:3efb79507e66efc3cc003477cdc11bdc462a603659c07c7749c16bfdbfc1560b \
+    --hash=sha256:42c267dcb50b19a60bc5c112f20b0c7615666d0b31fa04233f06fde37c7eb66a \
+    --hash=sha256:4e1928e486e761b258db51741fccec79046e909c355e4d131e2ec9e5eb4accda \
+    --hash=sha256:5da38c4c84539903eadc8e1b0007d261f1bd5f5ec035199218682213f83736e0 \
+    --hash=sha256:72731cd6dfe533ae328f15504cf524aaacf8f0a5ab1410b8c69a183c625be9ac \
+    --hash=sha256:7bad626cdf1393f37ff537ea0aff0922e5ae7544ed66f44e13d3260237c082b8 \
+    --hash=sha256:7d17c08ebacafc94f8a56a36fbf1b970d806770e834eaa56db89190c649a9c2c \
+    --hash=sha256:8642a889b8ab4f2017b42881d91a6f2a5b3a0f8ee375511d5e87a3e4a54d3d43 \
+    --hash=sha256:8b8f3650b1969ee6eccf134ede49a97ca0226b711b032356429838bb57c62f82 \
+    --hash=sha256:c60e53e46dcc6f20d51681297ec92f2460be678e4d39ffa41b984443a33ced7d \
+    --hash=sha256:dfecd250eb7093eab84453a5b4af71928c33d08dc840f2a81cfb5df49a0c34fd \
+    --hash=sha256:e70780972f3171a98795c806d8c461536063881ee8de68dcc0dfc1788df4512f \
+    --hash=sha256:e99c0d22ed538eb88672f66cf9058512b87c8d5df2326089226082f25815e3b2
     # via
     #   -r requirements.txt
     #   sslyze
@@ -597,9 +595,8 @@ protobuf==3.12.4 \
     #   -r requirements.txt
     #   google-api-core
     #   googleapis-common-protos
-pshtt==0.6.7 \
-    --hash=sha256:896015db7bfc4b6b0990840cbadfdbbf1c0afc2ba54214d6d60e09bfc21bd14a \
-    --hash=sha256:a387e26030671419189d38d7feb6ae090573380753b82f6880b7adf272efd445
+https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
+    --hash=sha256:56e10b98409223c2800c25268822468579a7dad0faebc8ed31f9d12ef7b80381
     # via -r requirements.txt
 psycopg2==2.7.3.2 \
     --hash=sha256:009e0bc09a57dbef4b601cb8b46a2abad51f5274c8be4bba276ff2884cd4cc53 \
@@ -792,7 +789,6 @@ six==1.11.0 \
     # via
     #   -r requirements.txt
     #   bleach
-    #   cryptography
     #   django-anymail
     #   django-logging-json
     #   google-api-core
@@ -822,8 +818,8 @@ sqlparse==0.3.0 \
     #   -r requirements.txt
     #   django
     #   django-debug-toolbar
-sslyze==2.1.4 \
-    --hash=sha256:fe8f7082e4915a675bccccb31e98537e1781214a4031e59feaa98ffe4b59b935
+sslyze==4.1.0 \
+    --hash=sha256:76a50297aa2e3f4d8e2660865ca648eff672b0a5967fa052bb26b8b05e0d3ff9
     # via
     #   -r requirements.txt
     #   pshtt
@@ -860,8 +856,8 @@ tldextract==2.2.0 \
     --hash=sha256:29797125db1f2e72ce2ee51f7a764ec8b1e6588812520795ffeae93bcd46bab4 \
     --hash=sha256:84a0b275c262e34df7506e10767e357e8b5a755a3a620cdc2cfe035061f7806d
     # via -r requirements.txt
-tls-parser==1.2.1 \
-    --hash=sha256:869ad3c8a45e73bcbb3bf0dd094f0345675c830e851576f42585af1a60c2b0e5
+tls-parser==1.2.2 \
+    --hash=sha256:83e4cb15b88b00fad1a856ff54731cc095c7e4f1ff90d09eaa24a5f48854da93
     # via
     #   -r requirements.txt
     #   sslyze
@@ -878,6 +874,13 @@ typepy[datetime]==1.1.1 \
     #   pytablereader
     #   pytablewriter
     #   tabledata
+typing-extensions==3.10.0.0 \
+    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
+    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
+    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+    # via
+    #   -r requirements.txt
+    #   sslyze
 unidecode==0.4.21 \
     --hash=sha256:280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051 \
     --hash=sha256:61f807220eda0203a774a09f84b4304a3f93b5944110cc132af29ddb81366883

--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
 	"variables": {
-		"SAFETY_IGNORE_IDS": ["38197", "38932", "39252", "39606"]
+		"SAFETY_IGNORE_IDS": []
 	}
 }

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 https://github.com/freedomofpress/django-logging/zipball/34fbeeea7a83bd54f8551bb50382a06b69814d4e
+https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304
 bleach>=3.1.3
 Django>=2.2.20,<2.3
 django-anymail[mailgun]>=1.4
@@ -12,7 +13,6 @@ feedparser
 gunicorn>=20.1.0
 lxml>=4.6.3
 pillow>=6.2.3
-pshtt
 psycopg2
 pyopenssl==19.0.0
 pygments

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,6 @@ anyascii==0.1.7 \
     --hash=sha256:d0eb076933a9eaf1138cb365a5e2e35360ffbbf3200bf33419aaa17d5f8599f5 \
     --hash=sha256:f100a4f716867bcf0a3b05d8a183dd122fc1d55304a10127bee256e602452d61
     # via wagtail
-asn1crypto==1.4.0 \
-    --hash=sha256:4bcdf33c861c7d40bdcd74d8e4dd7661aac320fcdf40b9a3f95b4ee12fde2fa8 \
-    --hash=sha256:f4f6e119474e58e04a2b1af817eb585b4fd72bdd89b998624712b5c99be7641c
-    # via cryptography
 attrs==20.2.0 \
     --hash=sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594 \
     --hash=sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc
@@ -72,26 +68,19 @@ chardet==3.0.4 \
     # via
     #   mbstrdecoder
     #   requests
-cryptography==2.5 \
-    --hash=sha256:05b3ded5e88747d28ee3ef493f2b92cbb947c1e45cf98cfef22e6d38bb67d4af \
-    --hash=sha256:06826e7f72d1770e186e9c90e76b4f84d90cdb917b47ff88d8dc59a7b10e2b1e \
-    --hash=sha256:08b753df3672b7066e74376f42ce8fc4683e4fd1358d34c80f502e939ee944d2 \
-    --hash=sha256:2cd29bd1911782baaee890544c653bb03ec7d95ebeb144d714b0f5c33deb55c7 \
-    --hash=sha256:31e5637e9036d966824edaa91bf0aa39dc6f525a1c599f39fd5c50340264e079 \
-    --hash=sha256:42fad67d7072216a49e34f923d8cbda9edacbf6633b19a79655e88a1b4857063 \
-    --hash=sha256:4946b67235b9d2ea7d31307be9d5ad5959d6c4a8f98f900157b47abddf698401 \
-    --hash=sha256:522fdb2809603ee97a4d0ef2f8d617bc791eb483313ba307cb9c0a773e5e5695 \
-    --hash=sha256:6f841c7272645dd7c65b07b7108adfa8af0aaea57f27b7f59e01d41f75444c85 \
-    --hash=sha256:7d335e35306af5b9bc0560ca39f740dfc8def72749645e193dd35be11fb323b3 \
-    --hash=sha256:8504661ffe324837f5c4607347eeee4cf0fcad689163c6e9c8d3b18cf1f4a4ad \
-    --hash=sha256:9260b201ce584d7825d900c88700aa0bd6b40d4ebac7b213857bd2babee9dbca \
-    --hash=sha256:9a30384cc402eac099210ab9b8801b2ae21e591831253883decdb4513b77a3cd \
-    --hash=sha256:9e29af877c29338f0cab5f049ccc8bd3ead289a557f144376c4fbc7d1b98914f \
-    --hash=sha256:ab50da871bc109b2d9389259aac269dd1b7c7413ee02d06fe4e486ed26882159 \
-    --hash=sha256:b13c80b877e73bcb6f012813c6f4a9334fcf4b0e96681c5a15dac578f2eedfa0 \
-    --hash=sha256:bfe66b577a7118e05b04141f0f1ed0959552d45672aa7ecb3d91e319d846001e \
-    --hash=sha256:e091bd424567efa4b9d94287a952597c05d22155a13716bf5f9f746b9dc906d3 \
-    --hash=sha256:fa2b38c8519c5a3aa6e2b4e1cf1a549b54acda6adb25397ff542068e73d1ed00
+cryptography==3.4.7 \
+    --hash=sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d \
+    --hash=sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959 \
+    --hash=sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6 \
+    --hash=sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873 \
+    --hash=sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2 \
+    --hash=sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713 \
+    --hash=sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1 \
+    --hash=sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177 \
+    --hash=sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250 \
+    --hash=sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca \
+    --hash=sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d \
+    --hash=sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9
     # via
     #   pyopenssl
     #   sslyze
@@ -328,15 +317,26 @@ msgfy==0.1.0 \
     --hash=sha256:474c08302cd56ccee1300ac7976a01ebd1e42716fc9bcd947d39a311a15b7012 \
     --hash=sha256:ce8a8c8c223279fa0a2c0f278eec139fcf761ca4eb98f179f54a1b96f53514f5
     # via pytablewriter
-nassl==2.2.0 \
-    --hash=sha256:2cad7e728aca58a97c8f6dee2efa3a922e1d5a7090d179cf01ddbb26788e734a \
-    --hash=sha256:2e59f62f8001ef996fdb2ebf242019e5c9d97e269dda43dfe836db0c42fee60a \
-    --hash=sha256:7b48f07e1a7778b8b9ba6ab23db52a0e6e226f6eb5a6ce430b860c020b3cef04 \
-    --hash=sha256:7dd0c5335e787c00c7eb7e20119e7dc132732cbbfe4ee5c6b527501f4bb2c665 \
-    --hash=sha256:860093b431437acf48d34c1823a1e04eb536f8fd3a99fa271b382f1f9c62d899 \
-    --hash=sha256:889f63cb285ba1a8785531c2d6f9cc9a50f6193a83ee2615f4b2b42ccb229fca \
-    --hash=sha256:b19fa8828c86be4e4eced6d7e08982a17d97742f3d721d33bc90d14744173078 \
-    --hash=sha256:bc13593434d90c0a791d1d2d38c286e6d12034ae1c3c23a8b24ced1584b185ad
+nassl==4.0.0 \
+    --hash=sha256:002aa5b3bedde14b3641e6726b76474da8eb1611ff37b32fed1c1011b7a5e31b \
+    --hash=sha256:0550c4c7aeee6611066867af12cc5446a861870fe127ff22a93c8c892f950537 \
+    --hash=sha256:0f0a13be7c2ef64469a789d3797893fb6d2e058f61428d5e1021c78a8deda414 \
+    --hash=sha256:19c26de1f28f90df7bc3ad740b89f39d5e3a218e8105f6543f90960c9805055c \
+    --hash=sha256:2268a426f6c2818ae6d00aece54c5acc86fb65b898c4d33fe95d39980fbd4fe0 \
+    --hash=sha256:39da52cddea977bc2e97b474db5c253d9e1d76d932c9b2648ba457620659ff09 \
+    --hash=sha256:3efb79507e66efc3cc003477cdc11bdc462a603659c07c7749c16bfdbfc1560b \
+    --hash=sha256:42c267dcb50b19a60bc5c112f20b0c7615666d0b31fa04233f06fde37c7eb66a \
+    --hash=sha256:4e1928e486e761b258db51741fccec79046e909c355e4d131e2ec9e5eb4accda \
+    --hash=sha256:5da38c4c84539903eadc8e1b0007d261f1bd5f5ec035199218682213f83736e0 \
+    --hash=sha256:72731cd6dfe533ae328f15504cf524aaacf8f0a5ab1410b8c69a183c625be9ac \
+    --hash=sha256:7bad626cdf1393f37ff537ea0aff0922e5ae7544ed66f44e13d3260237c082b8 \
+    --hash=sha256:7d17c08ebacafc94f8a56a36fbf1b970d806770e834eaa56db89190c649a9c2c \
+    --hash=sha256:8642a889b8ab4f2017b42881d91a6f2a5b3a0f8ee375511d5e87a3e4a54d3d43 \
+    --hash=sha256:8b8f3650b1969ee6eccf134ede49a97ca0226b711b032356429838bb57c62f82 \
+    --hash=sha256:c60e53e46dcc6f20d51681297ec92f2460be678e4d39ffa41b984443a33ced7d \
+    --hash=sha256:dfecd250eb7093eab84453a5b4af71928c33d08dc840f2a81cfb5df49a0c34fd \
+    --hash=sha256:e70780972f3171a98795c806d8c461536063881ee8de68dcc0dfc1788df4512f \
+    --hash=sha256:e99c0d22ed538eb88672f66cf9058512b87c8d5df2326089226082f25815e3b2
     # via sslyze
 oauthlib==2.0.6 \
     --hash=sha256:ce57b501e906ff4f614e71c36a3ab9eacbb96d35c24d1970d2539bbc3ec70ce1
@@ -418,9 +418,8 @@ protobuf==3.12.4 \
     # via
     #   google-api-core
     #   googleapis-common-protos
-pshtt==0.6.7 \
-    --hash=sha256:896015db7bfc4b6b0990840cbadfdbbf1c0afc2ba54214d6d60e09bfc21bd14a \
-    --hash=sha256:a387e26030671419189d38d7feb6ae090573380753b82f6880b7adf272efd445
+https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304 \
+    --hash=sha256:56e10b98409223c2800c25268822468579a7dad0faebc8ed31f9d12ef7b80381
     # via -r requirements.in
 psycopg2==2.7.3.2 \
     --hash=sha256:009e0bc09a57dbef4b601cb8b46a2abad51f5274c8be4bba276ff2884cd4cc53 \
@@ -550,7 +549,6 @@ six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb
     # via
     #   bleach
-    #   cryptography
     #   django-anymail
     #   django-logging-json
     #   google-api-core
@@ -573,8 +571,8 @@ sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
     # via django
-sslyze==2.1.4 \
-    --hash=sha256:fe8f7082e4915a675bccccb31e98537e1781214a4031e59feaa98ffe4b59b935
+sslyze==4.1.0 \
+    --hash=sha256:76a50297aa2e3f4d8e2660865ca648eff672b0a5967fa052bb26b8b05e0d3ff9
     # via pshtt
 tabledata==1.1.3 \
     --hash=sha256:59cc3b5f0c52ea142386b0653d3d48d2e976fe021154871982b4d234b82be747 \
@@ -602,8 +600,8 @@ tldextract==2.2.0 \
     --hash=sha256:29797125db1f2e72ce2ee51f7a764ec8b1e6588812520795ffeae93bcd46bab4 \
     --hash=sha256:84a0b275c262e34df7506e10767e357e8b5a755a3a620cdc2cfe035061f7806d
     # via -r requirements.in
-tls-parser==1.2.1 \
-    --hash=sha256:869ad3c8a45e73bcbb3bf0dd094f0345675c830e851576f42585af1a60c2b0e5
+tls-parser==1.2.2 \
+    --hash=sha256:83e4cb15b88b00fad1a856ff54731cc095c7e4f1ff90d09eaa24a5f48854da93
     # via sslyze
 typepy[datetime]==1.1.1 \
     --hash=sha256:418e24c44cf5fc260c2e2bbc68a3d0bc8c43f488412663c7ce1f33efa5133323 \
@@ -613,6 +611,11 @@ typepy[datetime]==1.1.1 \
     #   pytablereader
     #   pytablewriter
     #   tabledata
+typing-extensions==3.10.0.0 \
+    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
+    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
+    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+    # via sslyze
 unidecode==0.4.21 \
     --hash=sha256:280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051 \
     --hash=sha256:61f807220eda0203a774a09f84b4304a3f93b5944110cc132af29ddb81366883


### PR DESCRIPTION
This pull request switches `pshtt` to the version of it we have forked. Also upgrades related packages where possible, namely `cryptography`, which means we can also un-ignore all the safety checks we have been previously ignoring.

Fixes #844 