### PR TITLE
Update Matomo/Piwik tracking code to match latest recommendation

### DIFF
--- a/securedrop/static/js/piwik.js
+++ b/securedrop/static/js/piwik.js
@@ -1,9 +1,11 @@
-var idSite = 3;
-var piwikTrackingApiUrl = 'https://analytics.freedom.press/piwik.php';
-
 var _paq = window._paq = window._paq || [];
-
-_paq.push(['setTrackerUrl', piwikTrackingApiUrl]);
-_paq.push(['setSiteId', idSite]);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
+(function() {
+    var u="https://analytics.freedom.press/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '3']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -53,7 +53,6 @@
 
 		{% if django_settings.ANALYTICS_ENABLED %}
 			<script type="text/javascript" src="{% static 'js/piwik.js' %}"></script>
-			<script src="https://analytics.freedom.press/piwik.js" async defer></script>
 			<noscript><p><img src="https://analytics.freedom.press/piwik.php?idsite=3" alt="" /></p></noscript>
 		{% endif %}
 	</body>


### PR DESCRIPTION
This pull request updates the Matomo tracking code to match the latest recommended use of their tracking code. Notably, the loading of the `https://analytics.freedom.press/piwik.js` resource is moved into the JS file itself, instead of being loaded via a script tag.

Fixes #809