### PR TITLE
Change django-logging encoding from 'ascii' to 'utf-8'

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -401,6 +401,7 @@ DJANGO_LOGGING = {
     "DISABLE_EXISTING_LOGGERS": True,
     "PROPOGATE": False,
     "SQL_LOG": False,
+    "ENCODING": "utf-8",
 }
 
 LOGGING = {


### PR DESCRIPTION
The default is not acceptable for logging the "content" response, which may contain non-ascii characters.  Even though we are ultimately discarding the content, `django-logging` still encodes it first.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/180