### PR TITLE
Manual scans of SecureDrop landing pages

### DIFF
--- a/directory/forms.py
+++ b/directory/forms.py
@@ -6,3 +6,15 @@ class ScannerForm(forms.Form):
     required_css_class = 'basic-form__required'
 
     url = forms.URLField()
+
+
+class ManualScanForm(forms.Form):
+    landing_page_url = forms.URLField(required=True)
+    permitted_domains = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 5, 'cols': 20}),
+        help_text=('Optional comma-separated list of additional domains that will not trigger '
+                   'the cross domain asset warning for this landing page.  '
+                   'Subdomains on domains in this list are ignored.  For example, '
+                   'adding "news.bbc.co.uk" permits all assets from "bbc.co.uk".'),
+    )

--- a/directory/templates/modeladmin/scan_form.html
+++ b/directory/templates/modeladmin/scan_form.html
@@ -1,0 +1,46 @@
+{% extends "wagtailadmin/base.html" %}
+
+{% block titletag %}{{ view.get_meta_title }}{% endblock %}
+
+{% block content %}
+	{% block header %}
+		<header class="nice-padding hasform">
+			<div class="row">
+				<div class="left">
+					<div class="col">
+						{% block h1 %}<h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>{{ view.get_page_title }}<span></span></h1>{% endblock %}
+					</div>
+				</div>
+			</div>
+		</header>
+	{% endblock %}
+
+	{% block content_main %}
+		<section class="nice-padding">
+			<h2>Manual Scan</h2>
+			<form action="" method="post">{% csrf_token %}
+				<ul class="fields">
+					{% for field in form %}
+						<li{% if field.field.required %} class="required"{% endif %}>
+							<div class="field char_field">
+								<label for="{{ field.html_id }}">
+									{{ field.label }}:
+								</label>
+								<div class="field-content">
+									<div class="input">
+										{{ field }}
+									</div>
+									{% if field.help_text %}
+										<p class="help">{{ field.help_text }}</p>
+									{% endif %}
+								</div>
+							</div>
+						</li>
+					{% endfor %}
+				</ul>
+				<input type="submit" value="Begin Scan" class="button" />
+			</form>
+		</section>
+	{% endblock content_main %}
+
+{% endblock content %}

--- a/directory/views.py
+++ b/directory/views.py
@@ -1,0 +1,34 @@
+from django.http import HttpResponseRedirect
+from django.views.generic.edit import FormView
+
+from scanner.scanner import perform_scan
+
+from .forms import ManualScanForm
+
+
+class ManualScanView(FormView):
+    model_admin = None
+    template_name = 'modeladmin/scan_form.html'
+    form_class = ManualScanForm
+    page_title = 'Manual Scan'
+
+    def get_page_title(self):
+        return self.page_title
+
+    def get_meta_title(self):
+        return self.get_page_title()
+
+    def form_valid(self, form):
+        from .wagtail_hooks import ScanResultAdmin
+
+        scanresult_modeladmin = ScanResultAdmin()
+
+        permitted_domains = form.cleaned_data['permitted_domains'].split(',')
+        landing_page_url = form.cleaned_data['landing_page_url']
+
+        result = perform_scan(landing_page_url, permitted_domains)
+        result.save()
+
+        result_url = scanresult_modeladmin.url_helper.get_action_url('inspect', result.pk)
+
+        return HttpResponseRedirect(result_url)


### PR DESCRIPTION
Refs #803 

This pull request adds a "Perform a Scan" button to the "Scan Results" section of the admin, as shown in the top right corner:

![image](https://user-images.githubusercontent.com/561931/121408175-1e5caa00-c92e-11eb-9cb7-b7193cc418ff.png)

From there, you can supply the needed information and the scan will be done based on what you tell it:

![image](https://user-images.githubusercontent.com/561931/121408289-3f24ff80-c92e-11eb-9793-184c02eae46f.png)

The scan might take a little white to complete, but when it is, you will be redirected to the "Inspect" view for that result. For example:

![image](https://user-images.githubusercontent.com/561931/121408495-7a273300-c92e-11eb-8836-7ecf6d5b412c.png)

This feature is available to any user who has "Create" permissions for Scan Result objects, which can be configured on a per-group basis.

I've tried to do things mostly in line with how Wagtail's Model Admins work, with the manual scan serving the role of the "create" action on `ScanResult` models, which I think actually works out fairly nicely. There are some more technical details I've written a little bit about in the commit messages.