### PR TITLE
Log to the console by default

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -372,7 +372,7 @@ CSP_REPORT_URI = os.environ.get('DJANGO_CSP_REPORT_URI',
 
 log_level = os.environ.get("DJANGO_LOG_LEVEL", "info").upper()
 log_format = os.environ.get("DJANGO_LOG_FORMAT", "json")
-log_stdout = False
+log_stdout = True
 log_handler = {
     "formatter": log_format,
     "class": "logging.StreamHandler",


### PR DESCRIPTION
This pull request changes the log configuration settings so that logs are directed to the console by default. Logs will only be sent to a file if `DJANGO_LOG_DIR` is configured. I believe this is how our system was intended to work and it was changed inadvertently.