### PR TITLE
Update container base images

### DIFF
--- a/devops/docker/CI-Dockerfile
+++ b/devops/docker/CI-Dockerfile
@@ -1,6 +1,5 @@
-# sha256 as of 2020-12-11 for stretch
-FROM debian@sha256:1dbc66ba61e22d1c4fe1b9d592b0e64c21dc8521f1ecb0bb841eb026830d2c91
-
+# sha256 as of 2021-07-22
+FROM debian:stretch@sha256:73ac83a515905726362515b1e1f00db1b8a4274103acf50d6c21073b1fbc0473
 
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VER 17.05.0-ce

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2021-05-10 for 3.9-slim-buster
-FROM python@sha256:655f71f243ee31eea6774e0b923b990cd400a0689eff049facd2703e57892447
+# sha256 as of 2021-07-22
+FROM python:3.9-slim-buster@sha256:4e69709296a8ae67d97ba072e7f4973125939f3a13cd276c1e8ca1f7b7d49aa3
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/devops/docker/NodeDockerfile
+++ b/devops/docker/NodeDockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2021-03-24 for 14-alpine
-FROM node@sha256:a75f7cc536062f9266f602d49047bc249826581406f8bc5a6605c76f9ed18e98
+# sha256 as of 2021-07-22
+FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5
 
 # Install npm, making output less verbose
 ARG NPM_VER=6.14.11

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2021-03-24 for 14-alpine
-FROM node@sha256:a75f7cc536062f9266f602d49047bc249826581406f8bc5a6605c76f9ed18e98 AS node-assets
+# sha256 as of 2021-07-22
+FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5 AS node-assets
 
 # Install npm, making output less verbose
 ARG NPM_VER=6.14.11


### PR DESCRIPTION
Since we've done upgrades across the board for https://github.com/freedomofpress/infrastructure/issues/3481, it seemed like a good time to roll through and update all container bases.

Note that the containers do not include systemd or the kernel itself; this is just keeping things up to date.