### PR TITLE
Label accessibility

### DIFF
--- a/directory/templates/directory/directory_page.html
+++ b/directory/templates/directory/directory_page.html
@@ -55,7 +55,7 @@
 				</div>
 				<div class="filters__wrapper--last">
 					<label class="sr-only" for="aria-topic">{% trans "Topic" %}</label>
-					<select name="topic" label="Topic" class="filters__field filters__field--select">
+					<select id="aria-topic" name="topic" label="Topic" class="filters__field filters__field--select">
 						<option {% if not entries_filters.topics %}selected{% endif %}  disabled>
 							{% trans "Topic" %}
 						</option>

--- a/search/templates/search/_search_bar.html
+++ b/search/templates/search/_search_bar.html
@@ -5,7 +5,9 @@
 		{% trans "Search" as search_alt_text %}
 		{% include "common/_svg.html" with class="search-bar__icon" svg="images/search.svg" img="images/search.png" alt=search_alt_text %}
 
+		<label class="sr-only" for="aria-site-search">Search</label>
 		<input
+			id="aria-site-search"
 			type="text"
 			class="search-bar__input search-bar__input--{{ location }}"
 			{% if search_query %} value="{{ search_query }}"{% endif %}


### PR DESCRIPTION
This PR fixes the first two tasks in #865:

1. Adds a missing `id` attribute on the directory page for the Topic dropdown
2. Adds a screen-reader only label for the search box on the Search page.