### PR TITLE
Adds a skip link to every page and adds context for links

### DIFF
--- a/accounts/templates/account/signup.html
+++ b/accounts/templates/account/signup.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-	<h1>{% trans "Sign up" %}</h1>
+	<h1 id="title">{% trans "Sign up" %}</h1>
 
 	<p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
 

--- a/accounts/templates/accounts/change_name.html
+++ b/accounts/templates/accounts/change_name.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-	<h1>{% trans "Change Name" %}</h1>
+	<h1 id="title">{% trans "Change Name" %}</h1>
 	<form action="" method="post" class="basic-form">
 		{% csrf_token %}
 		{{ form.as_p }}

--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main %}
-	<h1>
+	<h1 id="title">
 		{% user_display user as user_display %}
     {% blocktrans %}
       {{ user_display }}

--- a/accounts/templates/allauth_2fa/authenticate.html
+++ b/accounts/templates/allauth_2fa/authenticate.html
@@ -10,7 +10,7 @@
 
 {% block main %}
 	<div class="allauth">
-		<h1>
+		<h1 id="title">
 			{% trans "Two-factor authentication" %}
 		</h1>
 		{% if settings.common.TwoFactorAuthSettings.authenticate_text %}

--- a/accounts/templates/allauth_2fa/backup_tokens.html
+++ b/accounts/templates/allauth_2fa/backup_tokens.html
@@ -10,7 +10,7 @@
 
 {% block main %}
 	<div class="allauth">
-		<h1>
+		<h1 id="title">
 			{% trans "Two-factor authentication backup tokens" %}
 		</h1>
 		{% if settings.common.TwoFactorAuthSettings.backup_tokens_text %}

--- a/accounts/templates/allauth_2fa/remove.html
+++ b/accounts/templates/allauth_2fa/remove.html
@@ -10,7 +10,7 @@
 
 {% block main %}
 	<div class="allauth">
-		<h1>
+		<h1 id="title">
 			{% trans "Disable two-factor authentication" %}
 		</h1>
 

--- a/accounts/templates/allauth_2fa/setup.html
+++ b/accounts/templates/allauth_2fa/setup.html
@@ -11,7 +11,7 @@
 
 {% block main %}
 	<div class="allauth">
-		<h1>
+		<h1 id="title">
 			{% trans "Set up two-factor authentication" %}
 		</h1>
 

--- a/accounts/templates/directory_management/securedroppage_form.html
+++ b/accounts/templates/directory_management/securedroppage_form.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block page_title %}
-	<h1 class="header__title">
+	<h1 class="header__title" id="title">
 		{% trans 'Editing' %} {{ object.title }}
 	</h1>
 {% endblock %}

--- a/blog/templates/blog/_blog_tease.html
+++ b/blog/templates/blog/_blog_tease.html
@@ -1,6 +1,7 @@
 {# This is used both on the blog index and the homepage sidebar. #}
 
 {% load wagtailcore_tags %}
+{% load i18n %}
 
 <div class="blog-tease">
 	<div class="blog-tease__hexagon-wrapper">

--- a/blog/templates/blog/_blog_tease.html
+++ b/blog/templates/blog/_blog_tease.html
@@ -37,6 +37,7 @@
 					<a
 						href="{% pageurl page %}"
 						class="blog-tease__link"
+						aria-label="{% trans 'Read more about ' %}{{ page.title }}"
 					>{{ link_text }}{% include 'common/chevron-right.svg' with class="blog-tease__chevron" %}</a>
 			</div>
 		</div>

--- a/blog/templates/blog/_sidebar_with_categories_and_release.html
+++ b/blog/templates/blog/_sidebar_with_categories_and_release.html
@@ -29,9 +29,17 @@
 			<h4 class="release-preview__tag">SecureDrop {{ current_release.tag_name }}</h4>
 			<div class="release-preview__date">{{ current_release.date|date:"E j, Y"}}</div>
 			<div class="release-preview__links">
-				<a href="{{ current_release.url }}" class="release-preview__link">Github</a>
+				<a
+					href="{{ current_release.url }}"
+					class="release-preview__link"
+					aria-label="{% trans 'Github link for SecureDrop' %} {{ current_release.tag_name }}"
+					>Github</a>
 				{% if current_release.blog_page %}
-					<a href="{% pageurl current_release.blog_page %}" class="release-preview__link">{% trans "Release notes" %}</a>
+					<a
+						href="{% pageurl current_release.blog_page %}"
+						class="release-preview__link"
+						aria-label="{% trans 'Release notes for SecureDrop' %} {{ current_release.tag_name }}"
+						>{% trans "Release notes" %}</a>
 				{% endif %}
 			</div>
 		{% endwith%}

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -19,7 +19,7 @@
 		<div class="blog-title">
 			{% include "common/_hexagon.svg" with class="blog-title__hexagon" category_slug=page.category.slug %}
 			<h2 class="blog-title__category"><a href="{% pageurl page.category %}" class="blog-title__category-link">{{ page.category }}</a></h2>
-			<h1>{{ page.title }}</h1>
+			<h1 id="title">{{ page.title }}</h1>
 		</div>
 		<article>
 			<div class="blog-page__date">

--- a/client/common/sass/_accessibility.sass
+++ b/client/common/sass/_accessibility.sass
@@ -5,3 +5,28 @@
 	width: 1px
 	height: 1px
 	overflow: hidden
+
+.skip-link
+	position: absolute
+	background: #fff
+	padding: 1rem 2rem 0.75rem
+	border: 5px solid #dddde0
+	font-weight: 700
+	line-height: 1
+	z-index: 600
+
+	&:link,
+	&:visited
+		color: #000
+		text-decoration: none
+
+	&:not(:focus)
+		white-space: nowrap
+		width: 1px
+		height: 1px
+		overflow: hidden
+		border: 0
+		padding: 0
+		clip: rect(0 0 0 0)
+		clip-path: inset(50%)
+		margin: -1px

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -888,9 +888,9 @@ traitlets==4.3.2 \
     --hash=sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835 \
     --hash=sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9
     # via ipython
-typepy[datetime]==1.2.0 \
-    --hash=sha256:96b4c50151ffaca025b7202cdd4e84987ca058f4d6cf1aad0d9c82226961455e \
-    --hash=sha256:d3cdabcabf1b6058ccaac1c7ef6a097ec3901a3a3ff79b0a038d8496b3900805
+typepy[datetime]==1.3.0 \
+    --hash=sha256:96788530614083164993d1443959f6c58e6bb8e2da839812ddf462c203e4b84c \
+    --hash=sha256:cf1913982969cf6348152c4a5feec08e324addd99670999e57cdb3ad87a61e9a
     # via
     #   -r requirements.txt
     #   dataproperty

--- a/directory/templates/directory/directory_entry.html
+++ b/directory/templates/directory/directory_entry.html
@@ -18,7 +18,7 @@
 				<img {{ image_1x.attrs }} srcset="{{ image_1x.url }} 1x, {{ image_2x.url }} 2x" />
 			</div>
 		{% endif %}
-		<h1 class="instance-title__header {% if page.organization_logo_is_title %}sr-only{% endif %}">
+		<h1 id="title" class="instance-title__header {% if page.organization_logo_is_title %}sr-only{% endif %}">
 			{{ page.title }}
 			{% if page.editable %}
 				<a href="{% url 'securedroppage_edit' page.slug %}" class="instance-title__edit-link">

--- a/directory/templates/directory/result.html
+++ b/directory/templates/directory/result.html
@@ -15,7 +15,7 @@
 
 {% block top %}
 <div class="instance-title">
-		<h1 class="instance-title__header">{% trans "Scan Result" %}</h1>
+		<h1 id="title" class="instance-title__header">{% trans "Scan Result" %}</h1>
 		<a class="instance-title__landing-page" href="{{ landing_page_url }}">{{ landing_page_url }}{% include "common/chevron-right.svg" with class="instance-title__chevron" %}</a>
 </div>
 {% endblock top %}

--- a/home/templates/home/_instances.html
+++ b/home/templates/home/_instances.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags	%}
 {% for highlighted_instance in instances %}
-	<a href="{% pageurl highlighted_instance.instance %}" class="instances__item">
+	<a href="{% pageurl highlighted_instance.instance %}" class="instances__item" aria-label="{{ page.instance_link_default_text }}: {{ highlighted_instance.instance.title }}">
 		{% if highlighted_instance.instance.organization_logo_homepage %}
 			{% image highlighted_instance.instance.organization_logo_homepage max-96x96 as logo_1x %}
 			{% image highlighted_instance.instance.organization_logo_homepage max-192x192 as logo_2x %}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -25,7 +25,7 @@
 	<div class="hero">
 		{% include "common/_svg.html" with class="hero__logo" svg="images/logo_transparent-HappyKeyhole2.svg" img="images/logo_transparent-HappyKeyhole-1x.png" alt="White cube with keyhole (Securedrop logo)" %}
 		<div class="hero__text">
-			<h1 class="sr-only">{{ self.get_site.site_name }}</h1>
+			<h1 id="title" class="sr-only">{{ self.get_site.site_name }}</h1>
 			{% include "common/_svg.html" with class="hero__title" svg="images/_site_title.svg" img="images/site_title.png" alt="Securedrop" %}
 			{% if page.description_header %}
 				<h2 class="hero__description-header">{{ page.description_header }}</h2>

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -66,11 +66,11 @@
 							</h3>
 							<div class="updates__date">{{ current_release.date|date:"E j, Y"}}</div>
 							<p>
-								<a href="{{ current_release.url }}" class="updates__link--secondary">GitHub</a>
+								<a href="{{ current_release.url }}" class="updates__link--secondary" aria-label="{% trans 'Github link for SecureDrop' %} {{ current_release.tag_name }}">GitHub</a>
 								{% if current_release.blog_page %}
-									| <a href="{% pageurl current_release.blog_page %}" class="updates__link--secondary">{% trans "Release notes" %}</a>
+									| <a href="{% pageurl current_release.blog_page %}" class="updates__link--secondary" aria-label="{% trans 'Release notes for SecureDrop' %} {{ current_release.tag_name }}">{% trans "Release notes" %}</a>
 								{% endif %}
-								| <a href="{{ page.docs_url }}" class="updates__link--secondary">Documentation</a>
+								| <a href="{{ page.docs_url }}" class="updates__link--secondary" aria-label="{% trans 'Documentation about SecureDrop' %} {{ current_release.tag_name }}">Documentation</a>
 							</p>
 						</div>
 					{% endif %}

--- a/marketing/templates/marketing/_features_list.html
+++ b/marketing/templates/marketing/_features_list.html
@@ -3,7 +3,7 @@
 <div class="features-list">
 	{% for feature in features %}
 		<div class="features-list__item-wrapper">
-			<a class="features-list__item" href="{% pageurl feature.feature %}">
+			<a class="features-list__item" href="{% pageurl feature.feature %}" arial-label="{% trans 'Know more about the feature: ' %}{{ feature.feature.teaser_title }}">
 				<div class="features-list__item-content">
 					{% if feature.feature.icon %}
 						{% image feature.feature.icon max-200x200 class='features-list__item-image' %}

--- a/marketing/templates/marketing/_features_list.html
+++ b/marketing/templates/marketing/_features_list.html
@@ -4,10 +4,10 @@
 <div class="features-list">
 	{% for feature in features %}
 		<div class="features-list__item-wrapper">
-			<a class="features-list__item" href="{% pageurl feature.feature %}" arial-label="{% trans 'Know more about the feature: ' %}{{ feature.feature.teaser_title }}">
+			<a class="features-list__item" href="{% pageurl feature.feature %}">
 				<div class="features-list__item-content">
 					{% if feature.feature.icon %}
-						{% image feature.feature.icon max-200x200 class='features-list__item-image' %}
+						{% image feature.feature.icon max-200x200 class='features-list__item-image' role='presentation' %}
 					{% endif %}
 					<div class="features-list__item-text">
 						<h2 class="features-list__item-heading">{{ feature.feature.teaser_title }}</h2>

--- a/marketing/templates/marketing/_features_list.html
+++ b/marketing/templates/marketing/_features_list.html
@@ -1,4 +1,5 @@
 {% load wagtailcore_tags wagtailimages_tags %}
+{% load i18n %}
 
 <div class="features-list">
 	{% for feature in features %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -614,9 +614,9 @@ tldextract==2.2.0 \
 tls-parser==1.2.2 \
     --hash=sha256:83e4cb15b88b00fad1a856ff54731cc095c7e4f1ff90d09eaa24a5f48854da93
     # via sslyze
-typepy[datetime]==1.2.0 \
-    --hash=sha256:96b4c50151ffaca025b7202cdd4e84987ca058f4d6cf1aad0d9c82226961455e \
-    --hash=sha256:d3cdabcabf1b6058ccaac1c7ef6a097ec3901a3a3ff79b0a038d8496b3900805
+typepy[datetime]==1.3.0 \
+    --hash=sha256:96788530614083164993d1443959f6c58e6bb8e2da839812ddf462c203e4b84c \
+    --hash=sha256:cf1913982969cf6348152c4a5feec08e324addd99670999e57cdb3ad87a61e9a
     # via
     #   dataproperty
     #   pytablereader

--- a/securedrop/templates/base.html
+++ b/securedrop/templates/base.html
@@ -5,6 +5,7 @@
 
 {% block body %}
 	{% wagtailuserbar %}
+	<a href="#title" class="skip-link">Skip to content</a>
 
 	{% block tor_warning %}
 		{% include 'common/_tor.html' %}
@@ -80,7 +81,7 @@
 
 				{% block page_title %}
 					<div class="header__title">
-						<h1 class="header__title-text">
+						<h1 id="title" class="header__title-text">
 							{% block page_title_text %}
 								{{ page.title }}
 							{% endblock %}

--- a/securedrop/templates/base.html
+++ b/securedrop/templates/base.html
@@ -2,10 +2,11 @@
 
 {% load wagtailuserbar wagtailcore_tags get_menu i18n static %}
 {% load render_bundle from webpack_loader %}
+{% load i18n %}
 
 {% block body %}
 	{% wagtailuserbar %}
-	<a href="#title" class="skip-link">Skip to content</a>
+	<a href="#title" class="skip-link">{% trans "Skip to content" %}</a>
 
 	{% block tor_warning %}
 		{% include 'common/_tor.html' %}


### PR DESCRIPTION
Fixes #873 
Fixes #872 

This PR adds a "Skip to content" link to every page that takes the user directly to the page-title of the page. The link is not visible unless someone uses tab to navigate and focuses on that link (which is always the very first link in the page). This is how it looks when focused:
![Screenshot from 2021-09-20 19-58-57](https://user-images.githubusercontent.com/9530293/134020073-b48d32cb-cda9-4251-a2e7-de76742c3f89.png)

Also, in this PR, I have added aria-label to links which have generic text like "Read more", "View in directory" to add more context. It doesn't change any visuals, but gives more context to screen reader and other assistive tech users.