### PR TITLE
Upgrade version script, add /health/version

### DIFF
--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -3,5 +3,9 @@ from django.test import TestCase
 
 class HealthCheckTestCase(TestCase):
     def test_health_check_url_returns_200_status(self):
-        self.response = self.client.get('/health/ok/')
+        self.response = self.client.get("/health/ok/")
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_version_info_url_returns_200_status(self):
+        self.response = self.client.get("/health/version/")
         self.assertEqual(self.response.status_code, 200)

--- a/common/views.py
+++ b/common/views.py
@@ -60,6 +60,7 @@ def health_ok(request):
     """Lightweight health-check with a 200 response code."""
     return HttpResponse("okay", content_type="text/plain")
 
+
 def health_version(request):
     """Also a health check, but returns the commit short-hash."""
     version_short_text = read_version_info_file(VERSION_INFO_SHORT_PATH)

--- a/common/views.py
+++ b/common/views.py
@@ -5,10 +5,15 @@ from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 
 
-DEPLOYINFO_PATH = os.environ.get('DJANGO_VERSION_FILE', '/deploy/version')
+VERSION_INFO_SHORT_PATH = os.environ.get(
+    "DJANGO_SHORT_VERSION_FILE", "/deploy/version-short.txt"
+)
+VERSION_INFO_FULL_PATH = os.environ.get(
+    "DJANGO_FULL_VERSION_FILE", "/deploy/version-full.txt"
+)
 
 
-def deploy_info_view(request):
+def read_version_info_file(p):
     """Read deployment info file that is written by the deployment system
 
     This file contains git info (recent commits, messages), python
@@ -17,11 +22,15 @@ def deploy_info_view(request):
 
     """
     try:
-        with open(DEPLOYINFO_PATH, 'r') as f:
-            contents = f.read()
+        with open(p, 'r') as f:
+            return f.read()
     except FileNotFoundError:
-        contents = "<file not found at {}>".format(DEPLOYINFO_PATH)
-    return HttpResponse(contents, content_type='text/plain')
+        return "<file not found at {}>".format(p)
+
+
+def deploy_info_view(request):
+    version_full_text = read_version_info_file(VERSION_INFO_FULL_PATH)
+    return HttpResponse(version_full_text, content_type="text/plain")
 
 
 def view_document(request, document_id, document_filename):
@@ -49,4 +58,9 @@ def view_document(request, document_id, document_filename):
 @never_cache
 def health_ok(request):
     """Lightweight health-check with a 200 response code."""
-    return HttpResponse("okay")
+    return HttpResponse("okay", content_type="text/plain")
+
+def health_version(request):
+    """Also a health check, but returns the commit short-hash."""
+    version_short_text = read_version_info_file(VERSION_INFO_SHORT_PATH)
+    return HttpResponse(version_short_text, content_type="text/plain")

--- a/securedrop/urls.py
+++ b/securedrop/urls.py
@@ -10,7 +10,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
-from common.views import view_document, health_ok
+from common.views import view_document, health_ok, health_version
 from accounts.urls import urlpatterns as account_urls
 from wagtailautocomplete.urls.admin import urlpatterns as autocomplete_admin_urls
 from wagtailautocomplete.views import objects, search, create
@@ -33,6 +33,7 @@ urlpatterns = [
 
     re_path(r'^document/view/(\d+)/(.*)$', view_document, name='view_document'),
     path('health/ok/', health_ok),
+    path('health/version/', health_version),
 
     path('search/', search_views.search, name='search'),
 


### PR DESCRIPTION
This adds a version endpoint, equivalent to https://github.com/freedomofpress/securethenews/pull/373. We have the same copy of the script (easier to read, new more-understandable branch output, but does not address the running at build time question), and a test. Basically nothing different.