### PR TITLE
Updates django to version 2.2.25

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -209,9 +209,9 @@ defusedxml==0.7.1 \
     # via
     #   -r requirements.txt
     #   python3-openid
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.txt
     #   django-allauth

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304
 bleach>=4.1.0
-Django>=2.2.24,<2.3
+Django>=2.2.25,<2.3
 django-anymail[mailgun]>=1.4
 django-modelcluster
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,9 +120,9 @@ defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \
     --hash=sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
     # via python3-openid
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
     #   django-allauth


### PR DESCRIPTION
Fixes CVE-2021-44420: Potential bypass of an upstream access control
based on URL paths

See https://docs.djangoproject.com/en/4.0/releases/2.2.25/ for more
information.