### PR TITLE
Update hook function signatures for latest version of wagtail

### DIFF
--- a/common/management/commands/tests/test_createdevdata.py
+++ b/common/management/commands/tests/test_createdevdata.py
@@ -1,0 +1,38 @@
+import os
+
+from django.contrib.auth.models import User
+from django.core import management
+from django.test import TestCase
+from django.urls import reverse
+from wagtail.core.models import Page
+
+
+class CreateDevDataTestCase(TestCase):
+    def test_createdevdata_works(self):
+        """The createdevdata command successfully creates functional pages
+
+        The createdevdata management command should run successfully,
+        without raising any exceptions, and the pages it generates
+        should return a 200 status code when requested, edited, and
+        explored in the wagtail admin.
+
+        """
+        # Write stdout to /dev/null so as not to clutter the output from the tests
+        with open(os.devnull, 'w') as devnull:
+            management.call_command('createdevdata', '--delete', '--no-download', stdout=devnull)
+
+        # We expect `createdevdata` to also make a superuser
+        self.client.force_login(User.objects.filter(is_superuser=True).first())
+
+        for page in Page.objects.exclude(slug='root'):
+            with self.subTest(page=page.specific):
+                response = self.client.get(page.get_url())
+                self.assertEqual(response.status_code, 200)
+
+                explore_url = reverse('wagtailadmin_explore', args=(page.pk,))
+                explore_response = self.client.get(explore_url)
+                self.assertEqual(explore_response.status_code, 200)
+
+                edit_url = reverse('wagtailadmin_pages:edit', args=(page.pk,))
+                edit_response = self.client.get(edit_url)
+                self.assertEqual(edit_response.status_code, 200)

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -69,7 +69,7 @@ scanresult_modeladmin = ScanResultAdmin()
 
 
 @hooks.register('register_page_listing_buttons')
-def add_scan_results_buttons(page, page_perms, is_parent=False):
+def add_scan_results_buttons(page, page_perms, is_parent=False, next_url=None):
     """
     For directory entry pages, add an additional button to the page listing,
     linking to the most relevant model admin pages for scan results.
@@ -86,7 +86,7 @@ def add_scan_results_buttons(page, page_perms, is_parent=False):
 
 
 @hooks.register('add_scan_results_button')
-def add_bundle_stats_button(page, page_perms, is_parent=False):
+def add_bundle_stats_button(page, page_perms, is_parent=False, next_url=None):
     """Creates drop-down buttons that link to ScanResult model admin
     sections for a given DirectoryEntry on the page listing area.  The
     links go to the most recent live result, as well as the filtered

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -86,7 +86,7 @@ def add_scan_results_buttons(page, page_perms, is_parent=False, next_url=None):
 
 
 @hooks.register('add_scan_results_button')
-def add_bundle_stats_button(page, page_perms, is_parent=False, next_url=None):
+def button_for_scan_results(page, page_perms, is_parent=False, next_url=None):
     """Creates drop-down buttons that link to ScanResult model admin
     sections for a given DirectoryEntry on the page listing area.  The
     links go to the most recent live result, as well as the filtered


### PR DESCRIPTION
This PR updates our hook functions for page listing See docs here:

- https://docs.wagtail.io/en/stable/reference/hooks.html#register-page-listing-buttons
- https://docs.wagtail.io/en/stable/reference/hooks.html#buttons-with-dropdown-lists


Also added tests that request some of the admin views that render the
hooks in question.  We have similar tests in other repos.