### PR TITLE
npm: Upgrade follow-redirects to 1.14.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2522,9 +2522,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "fraction.js": {
       "version": "4.1.2",


### PR DESCRIPTION
Fixes vulnerability described here:

https://github.com/advisories/GHSA-pw2r-vq6v-hr8c