### PR TITLE
Update `minimist` from version 1.2.5 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,9 +3130,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mississippi": {
       "version": "3.0.0",


### PR DESCRIPTION
Fixes a vulnerability described here:

https://github.com/advisories/GHSA-xvch-5gv4-984h