### PR TITLE
Don't log additional request_failed event if error is a 404

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 
+from django.http import Http404
 import structlog
 
 
@@ -24,7 +25,8 @@ class RequestLogMiddleware(object):
         self.response_keys = ('charset', 'reason_phrase', 'status_code')
 
     def process_exception(self, request, exception):
-        logger.exception("request_failed")
+        if not isinstance(exception, Http404):
+            logger.exception("request_failed")
 
     def __call__(self, request):
         # Code to be executed for each request before


### PR DESCRIPTION
Bring 404 handling into line with freedom.press. This is copied from @chigby's work there. If you make a 404ing request on each site, you'll see that freedom.press logs a `request_finished` event only, but here we log `request_finished` and `request_failed`.

All other 4xx response that generate an exception internally will still be logged at `error` level.