### PR TITLE
Simplify querystring logging

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -21,6 +21,7 @@ class RequestLogMiddleware(object):
             'HTTP_X_FORWARDED_FOR',
             'HTTP_X_REAL_IP',
             'HTTP_X_SCHEME',
+            'QUERY_STRING',
         )
         self.response_keys = ('charset', 'reason_phrase', 'status_code')
 
@@ -36,9 +37,6 @@ class RequestLogMiddleware(object):
         request_id = str(uuid.uuid4())
 
         request_dict = {key: getattr(request, key, '') for key in self.request_keys}
-        if request.GET:
-            request_dict["query_string_raw"] = request.GET.urlencode()
-            request_dict["query_string_parsed"] = request.GET.dict()
         request_dict["user"] = str(request_dict["user"])
         request_dict["meta"] = {
             key: request.META.get(key, "") for key in self.request_meta_keys

--- a/common/middleware.py
+++ b/common/middleware.py
@@ -20,7 +20,7 @@ class RequestLogMiddleware(object):
             'HTTP_HOST',
             'HTTP_X_FORWARDED_FOR',
             'HTTP_X_REAL_IP',
-            'HTTP_X_SCEHEME',
+            'HTTP_X_SCHEME',
         )
         self.response_keys = ('charset', 'reason_phrase', 'status_code')
 

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -102,7 +102,7 @@ class RequestLogTestCase(TestCase):
                     'HTTP_USER_AGENT': user_agent,
                     'HTTP_X_FORWARDED_FOR': forwarded_for,
                     'HTTP_X_REAL_IP': real_ip,
-                    'HTTP_X_SCEHEME': '',
+                    'HTTP_X_SCHEME': '',
                 },
                 'method': 'GET',
                 'path_info': '/',

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -67,7 +67,7 @@ class RequestLogTestCase(TestCase):
         real_ip = '2.2.2.2'
 
         request = self.factory.get(
-            '/',
+            '/?key=value',
             HTTP_USER_AGENT=user_agent,
             HTTP_X_FORWARDED_FOR=forwarded_for,
             HTTP_HOST=host,
@@ -103,6 +103,7 @@ class RequestLogTestCase(TestCase):
                     'HTTP_X_FORWARDED_FOR': forwarded_for,
                     'HTTP_X_REAL_IP': real_ip,
                     'HTTP_X_SCHEME': '',
+                    'QUERY_STRING': 'key=value',
                 },
                 'method': 'GET',
                 'path_info': '/',

--- a/directory/tests/test_filters.py
+++ b/directory/tests/test_filters.py
@@ -101,11 +101,11 @@ class DirectoryLanguageFilterTest(TestCase):
         spanish.save()
         chinese.save()
         # set up instances that are children of the directory and have those languages
-        self.spanish_instance = DirectoryEntryFactory(parent=self.directory)
+        self.spanish_instance = DirectoryEntryFactory(languages=0, parent=self.directory)
         self.spanish_instance.languages.add(spanish)
         self.spanish_instance.save()
 
-        self.chinese_instance = DirectoryEntryFactory(parent=self.directory)
+        self.chinese_instance = DirectoryEntryFactory(languages=0, parent=self.directory)
         self.chinese_instance.languages.add(chinese)
         self.chinese_instance.save()
         self.lang_filter = {'languages': spanish}

--- a/directory/tests/test_filters.py
+++ b/directory/tests/test_filters.py
@@ -114,7 +114,7 @@ class DirectoryLanguageFilterTest(TestCase):
         filtered_instances = self.directory.get_instances(filters=self.lang_filter)
         self.assertIn(self.spanish_instance, filtered_instances)
 
-    def test_langauge_not_filtered_for_is_not_in_queryset(self):
+    def test_language_not_filtered_for_is_not_in_queryset(self):
         filtered_instances = self.directory.get_instances(filters=self.lang_filter)
         self.assertNotIn(self.chinese_instance, filtered_instances)
 


### PR DESCRIPTION
Refs https://github.com/freedomofpress/pressfreedomtracker.us/pull/1494

request.GET is a QueryDict which isn't the friendliest object to use for obtaining log-worthy data (it's more meant for processing the query string in code), so let's do the simpler thing here, which also happens to be more readable.

Also makes some minor fixes to the bring the logging data into line with other repos, and fixes a flickering test.