### PR TITLE
Ignore gitpython vulnerability

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,5 +1,5 @@
 {
 	"variables": {
-		"SAFETY_IGNORE_IDS": ["41002", "51159"]
+		"SAFETY_IGNORE_IDS": ["41002", "51159", "52322"]
 	}
 }


### PR DESCRIPTION
The vulnerability is in the git clone functionality, especially when the URL used to clone is a unsanitized code execution string. Since we are never using gitpython ourselves so we are not cloning any URL supplied from the user. Also, bandit mentioned in their project that they are not using the cloning functionality either (https://github.com/PyCQA/bandit/issues/971#issuecomment-1345141340). So it's safe to ignore this vulnerability for us.