### PR TITLE
Docker and Readme Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
 
   build_dev:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2022.10.1
     working_directory: ~/securedrop.org
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ dev-init: ## Initialize docker environment for developer workflow
 
 .PHONY: check-migrations
 check-migrations: ## Check for ungenerated migrations
-	docker-compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
+	docker compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
 
 .PHONY: ci-tests
 ci-tests: ## Runs testinfra against a pre-running CI container. Useful for debug
@@ -21,18 +21,18 @@ ci-tests: ## Runs testinfra against a pre-running CI container. Useful for debug
 
 .PHONY: dev-tests
 dev-tests: ## Run django tests against developer environment
-	docker-compose exec django /bin/bash -ec \
+	docker compose exec django /bin/bash -ec \
 		"coverage run --source='.' ./manage.py test --noinput --keepdb; \
 		coverage html --skip-empty --omit='*/migrations/*.py,*/tests/*.py'; \
 		coverage report -m --fail-under=70 --skip-empty --omit='*/migrations/*.py,*/tests/*.py'"
 
 .PHONY: dev-createdevdata
 dev-createdevdata: ## Inject development data into the postgresql database
-	docker-compose exec django /bin/bash -c "./manage.py createdevdata"
+	docker compose exec django /bin/bash -c "./manage.py createdevdata"
 
 .PHONY: dev-import-db
 dev-import-db: ## Imports a database dump from file named ./import.db
-	docker-compose exec -it postgresql bash -c "cat /django/import.db | sed 's/OWNER\ TO\ [a-z]*/OWNER\ TO\ postgres/g' | psql securedropdb -U postgres &> /dev/null"
+	docker compose exec -it postgresql bash -c "cat /django/import.db | sed 's/OWNER\ TO\ [a-z]*/OWNER\ TO\ postgres/g' | psql securedropdb -U postgres &> /dev/null"
 
 .PHONY: dev-save-db
 dev-save-db: ## Save a snapshot of the database for the current git branch
@@ -97,15 +97,15 @@ lint: flake8
 
 .PHONY: flake8
 flake8: ## Runs flake8 linting in Python3 container.
-	@docker-compose run --rm -T django /bin/bash -c "flake8"
+	@docker compose run --rm -T django /bin/bash -c "flake8"
 
 .PHONY: bandit
 bandit: ## Runs bandit static code analysis in Python3 container.
-	@docker-compose run --rm django ./scripts/bandit
+	@docker compose run --rm django ./scripts/bandit
 
 .PHONY: npm-audit
 npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities
-	@docker-compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus'
+	@docker compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus'
 
 .PHONY: clean
 clean: ## clean out local developer assets

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ To get started, run:
 .. code:: bash
 
     make dev-init  # one-time command
-    docker-compose up  # long-running process to run application server, every time
+    docker compose up  # long-running process to run application server, every time
 
     # In a separate shell:
     docker-compose exec django ./manage.py createdevdata  # one-time command
@@ -58,7 +58,7 @@ To start the environment, run the following your first run:
 
 .. code:: bash
 
-    docker-compose up
+    docker compose up
 
 This is how you start the server every time you are working on the project. This will start a long-running process. You can exit this process with ``ctl-c``. You may wish to open a second shell to run one-off commands while the server is running.
 
@@ -72,12 +72,12 @@ To populate the project with data suitable for development and testing.
 
 You should be able to hit the web server interface at ``http://localhost:8000/``. You can access the Wagtail admin at ``http://localhost:8000/admin/``.
 
-To learn more about Docker Compose, see the `docker-compose CLI docs <https://docs.docker.com/compose/reference/overview/>`_
+To learn more about Docker Compose, see the `docker compose CLI docs <https://docs.docker.com/compose/reference/overview/>`_
 
 Management Commands
 -------------------
 
-In addition to the management commands provided by `Django <https://docs.djangoproject.com/en/stable/ref/django-admin/>`_ and `Wagtail <http://docs.wagtail.io/en/stable/reference/management_commands.html>`_, the project has a set of its own custom management commands. All commands listed should be prefaced by ``docker-compose exec django ./manage.py``.
+In addition to the management commands provided by `Django <https://docs.djangoproject.com/en/stable/ref/django-admin/>`_ and `Wagtail <http://docs.wagtail.io/en/stable/reference/management_commands.html>`_, the project has a set of its own custom management commands. All commands listed should be prefaced by ``docker compose exec django ./manage.py``.
 
 Dev Data Commands
 +++++++++++++++++
@@ -172,7 +172,7 @@ Database import
 +++++++++++++++
 
 Drop a Postgres database dump into the root of the repo and rename it to
-``import.db``. To import it into a running dev session (ensure ``docker-compose up`` has
+``import.db``. To import it into a running dev session (ensure ``docker compose up`` has
 already been started) run ``make dev-import-db``. Note that this will not pull in
 images that are referenced from an external site backup.
 
@@ -180,7 +180,7 @@ Connect to PostgreSQL service from host
 +++++++++++++++++++++++++++++++++++++++
 
 The postgresql service is exposed to your host on a port that will be displayed
-to you in the output of ``docker-compose port postgresql 5432``. If you have a GUI
+to you in the output of ``docker compose port postgresql 5432``. If you have a GUI
 database manipulation application you'd like to utilize point it to ``localhost``
 with the correct port, username ``securedrop``, password ``securedroppassword``, dbname ``securedropdb``
 
@@ -193,7 +193,7 @@ Note that build time for this container takes much longer than the developer env
 
 .. code:: bash
 
-    docker-compose -f prod-docker-compose.yaml up
+    docker compose -f prod-docker-compose.yaml up
 
 It is not run using live-code refresh so it's not a great dev environment but is good for replicating issues
 that would come up in production.
@@ -248,22 +248,22 @@ Sometimes when dependencies are changed or a Docker image needs to be updated fo
 
 .. code:: shell
 
-    docker-compose up --build
+    docker compose up --build
 
 Adding the ``--build`` flag tells Docker Compose to detect and update any images that require new changes. You can safely add the ``--build`` flag under most circumstances without adverse effects.
 
 .. code:: shell
 
-    docker-compose up --build --force-recreate
+    docker compose up --build --force-recreate
 
 Adding the ``--force-recreate`` flag tells Docker Compose to recreate all containers that are part of the application.
 
-If neither of the above fix the issues you're encountering, ensure all docker containers are stopped (``ctl-c`` if containers are running in a shell, ``docker-compose kill`` if they are running detached) and run the following commands. These commands will remove all images ad containers and rebuild from scratch. Any data in your database will be wiped.
+If neither of the above fix the issues you're encountering, ensure all docker containers are stopped (``ctl-c`` if containers are running in a shell, ``docker compose kill`` if they are running detached) and run the following commands. These commands will remove all images ad containers and rebuild from scratch. Any data in your database will be wiped.
 
 .. code:: shell
 
-    docker-compose rm
-    docker-compose up --build
+    docker compose rm
+    docker compose up --build
 
 
 Debugging
@@ -279,6 +279,6 @@ Second, attach to the running Django container.  This must be done in a shell, a
 
 .. code:: bash
 
-    docker attach $(docker-compose ps -q django)
+    docker attach $(docker compose ps -q django)
 
 Once you have done this, you can load the page that will run the code with your ``import ipdb`` and the debugger will activate in the shell you attached.  To detach from the shell without stopping the container press ``Control+P`` followed by ``Control+Q``.

--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,25 @@ Table of Contents
 Prerequisites
 -------------
 
-The installation instructions below assume you have the following software on your machine:
+The installation instructions below assume you have Docker on your machine.  The easiest way to achieve this is to install `Docker Desktop <https://www.docker.com/products/docker-desktop/>`_ for your operating system by following the instructions in the appropriate link below:
 
-* `Docker <https://www.docker.com/get-started>`_
-* `docker-compose <https://docs.docker.com/compose/install/>`_
+* `Install Docker Desktop on Mac <https://docs.docker.com/desktop/install/mac-install/>`_
+* `Install Docker Desktop on Fedora Linux <https://docs.docker.com/desktop/install/fedora/>`_
+* `Install Docker Desktop on Ubuntu Linux <https://docs.docker.com/desktop/install/ubuntu/>`_
+* `Install Docker Desktop on other Linux distributions <https://docs.docker.com/desktop/install/linux-install/>`_
+
+The instructions also assume you have cloned this repository and are in a shell environment in the base directory of the clone.  If this is not the case, run these commands:
+
+.. code:: bash
+
+    git clone https://github.com/freedomofpress/securedrop.org.git
+    cd securedrop.org
+
 
 Getting Started: The Quick Version
 ----------------------------------
 
-To get started, run:
+To start the website running in your local environment, run these commands:
 
 .. code:: bash
 
@@ -39,14 +49,16 @@ To get started, run:
     docker compose up  # long-running process to run application server, every time
 
     # In a separate shell:
-    docker-compose exec django ./manage.py createdevdata  # one-time command
+    make dev-createdevdata  # one-time command
 
-Visit ``http://localhost:8000/`` to see the site or ``http://localhost:8000/admin/`` for the Wagtail admin.
+Visit ``http://localhost:8000/`` to see the site.
+
+The URL of the admin area is ``http://localhost:8000/admin/`` for the Wagtail admin.  Running the dev data creation command will create login credentials of username "test" and password "test".
 
 Getting Started: The Unabridged Edition
 ---------------------------------------
 
-The development environment uses Docker Compose to run the application server, database, and webpack compilation processes. If you are using Docker for Mac, this comes preinstalled.
+The development environment uses Docker Compose to run the application server, database, and webpack compilation processes.
 
 Before development you *must* run this one-time command.
 
@@ -66,7 +78,7 @@ To populate the project with data suitable for development and testing.
 
 .. code:: bash
 
-    docker-compose exec django ./manage.py createdevdata
+    make dev-createdevdata
 
 .. important:: Though your database will persist between *most* runs, it is recommended that you consider it ephemeral and do not use it to store data you don't wish to lose.
 

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,13 +1,29 @@
 # sha256 as of 2021-07-22
-FROM python:3.9-slim-buster@sha256:4e69709296a8ae67d97ba072e7f4973125939f3a13cd276c1e8ca1f7b7d49aa3
+FROM python:3.9-slim-buster@sha256:4e69709296a8ae67d97ba072e7f4973125939f3a13cd276c1e8ca1f7b7d49aa3 AS python-base
+RUN apt-get update && \
+    apt-get install -y \
+       gcc \
+    libpq-dev
 
+FROM python-base AS builder
+RUN pip install -U pip pip-tools wheel
+COPY dev-requirements.in requirements.in dev-requirements.txt requirements.txt ./
+COPY devops/docker/pip-compile.sh /usr/local/bin
+RUN pip-compile.sh
+
+# This build target extracts the requirements.txt files from the
+# previous stage and is intented to be used with
+# `docker build --output=...` or the make command `compile-pip-dependencies`
+FROM scratch AS requirements-artifacts
+COPY --from=builder dev-requirements.txt ./
+COPY --from=builder requirements.txt ./
+
+FROM python-base
 RUN apt-get update && apt-get install -y \
     curl \
-    gcc \
     build-essential \
     git \
     libffi-dev \
-    libpq-dev \
     libxml2-dev \
     libxslt-dev \
     libssl-dev \
@@ -19,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 COPY devops/docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
-COPY dev-requirements.txt /requirements.txt
+COPY --from=builder dev-requirements.txt /requirements.txt
 RUN pip install --require-hashes -r /requirements.txt
 
 ARG USERID

--- a/devops/docker/pip-compile.sh
+++ b/devops/docker/pip-compile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script constructs requirements.txt and dev-requirements.txt
+# from requirements.in and dev-requirements.in, respectively.
+# Intended to be run during the docker build process for the Django
+# image.
+
+set -e
+
+pip-compile --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file requirements.txt requirements.in
+
+pip-compile --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file dev-requirements.txt dev-requirements.in


### PR DESCRIPTION
Started as part of https://github.com/freedomofpress/fpf-www-projects/issues/297 and if we like this technique I can port it to our other repositories.

This pull request:

1. Updates the documentation for the initial docker setup to use the correct form of the "docker compose" command and generally be more useful and accurate.
2. Updates the development dockerfile to take advantage of multi-stage builds, particularly for the frequently used command "compile-pip-dependencies". See commit message for more details. I didn't change the other pip commands since I'm not sure how/if they are being really used by anyone. Maybe they should be updated too, or made nicer? Not sure.