### PR TITLE
Django 3.2.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ compile-pip-dependencies: ## Uses pip-compile to update requirements.txt
 	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
-		pip-compile --generate-hashes --no-header --output-file requirements.txt requirements.in && \
+		pip-compile --generate-hashes --no-header --allow-unsafe --output-file requirements.txt requirements.in && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --output-file dev-requirements.txt dev-requirements.in'
 
 .PHONY: pip-update

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -218,9 +218,9 @@ decorator==5.1.0 \
     # via
     #   ipdb
     #   ipython
-django==3.2.16 \
-    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
-    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
+django==3.2.17 \
+    --hash=sha256:59c39fc342b242fb42b6b040ad8b1b4c15df438706c1d970d416d63cdd73e7fd \
+    --hash=sha256:644288341f06ebe4938eec6801b6bd59a6534a78e4aedde2a153075d11143894
     # via
     #   -r requirements.txt
     #   django-anymail
@@ -1044,16 +1044,6 @@ safety==2.3.1 \
     --hash=sha256:6e6fcb7d4e8321098cf289f59b65051cafd3467f089c6e57c9f894ae32c23b71 \
     --hash=sha256:8f098d12b607db2756886280e85c28ece8db1bba4f45fc5f981f4663217bd619
     # via -r dev-requirements.in
-setuptools==65.5.1 \
-    --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
-    --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
-    # via
-    #   gunicorn
-    #   ipdb
-    #   ipython
-    #   pytablereader
-    #   pytablewriter
-    #   safety
 sgmllib3k==1.0.0 \
     --hash=sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9
     # via
@@ -1369,3 +1359,16 @@ yarl==1.7.2 \
 zxcvbn-python==4.4.24 \
     --hash=sha256:900b28cc5e96be4091d8778f19f222832890264e338765a1c1c09fca2db64b2d
     # via -r requirements.txt
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==67.1.0 \
+    --hash=sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378 \
+    --hash=sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300
+    # via
+    #   -r requirements.txt
+    #   gunicorn
+    #   ipdb
+    #   ipython
+    #   pytablereader
+    #   pytablewriter
+    #   safety

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304
 bleach>=4.1.0
-Django>=3.2.16,<3.3
+Django>=3.2.17,<3.3
 django-anymail[mailgun]>=1.4
 django-modelcluster
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,9 +119,9 @@ dataproperty==0.54.2 \
     #   pytablereader
     #   pytablewriter
     #   tabledata
-django==3.2.16 \
-    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
-    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
+django==3.2.17 \
+    --hash=sha256:59c39fc342b242fb42b6b040ad8b1b4c15df438706c1d970d416d63cdd73e7fd \
+    --hash=sha256:644288341f06ebe4938eec6801b6bd59a6534a78e4aedde2a153075d11143894
     # via
     #   -r requirements.in
     #   django-anymail
@@ -751,6 +751,11 @@ zxcvbn-python==4.4.24 \
     --hash=sha256:900b28cc5e96be4091d8778f19f222832890264e338765a1c1c09fca2db64b2d
     # via -r requirements.in
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==67.1.0 \
+    --hash=sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378 \
+    --hash=sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300
+    # via
+    #   gunicorn
+    #   pytablereader
+    #   pytablewriter


### PR DESCRIPTION
This pull request updates Django to the latest 3.2 release, which has a fix for this security vulnerability:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-23969

It also makes our `compile-pip-dependencies` command consistent with other repos for pinning setuptools.