### PR TITLE
Fix null character handling in directory search

### DIFF
--- a/directory/forms.py
+++ b/directory/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from directory.models.taxonomy import Language, Topic, Country
+
 
 class ManualScanForm(forms.Form):
     landing_page_url = forms.URLField(required=True)
@@ -10,4 +12,20 @@ class ManualScanForm(forms.Form):
                    'the cross domain asset warning for this landing page.  '
                    'Subdomains on domains in this list are ignored.  For example, '
                    'adding "news.bbc.co.uk" permits all assets from "bbc.co.uk".'),
+    )
+
+
+class FilterForm(forms.Form):
+    search = forms.CharField(required=False)
+    language = forms.ModelChoiceField(
+        required=False,
+        queryset=Language.objects.all(),
+    )
+    country = forms.ModelChoiceField(
+        required=False,
+        queryset=Country.objects.all(),
+    )
+    topic = forms.ModelChoiceField(
+        required=False,
+        queryset=Topic.objects.all(),
     )

--- a/directory/templates/directory/directory_page.html
+++ b/directory/templates/directory/directory_page.html
@@ -33,7 +33,7 @@
 						<option {% if not entries_filters.languages %}selected{% endif %} disabled>
 							{% trans "Language Accepted" %}
 						</option>
-						<option value="None">{% trans "Any language" %}</option>
+						<option value="">{% trans "Any language" %}</option>
 						{% for language in all_filters.languages %}
 							<option {% if entries_filters.languages == language %}selected{%endif%} value="{{language.id}}">{{language.title}}</option>
 						{% endfor %}
@@ -47,7 +47,7 @@
 						<option {% if not entries_filters.countries %}selected{% endif %} disabled>
 							{% trans "Country" %}
 						</option>
-						<option value="None">{% trans "Any country" %}</option>
+						<option value="">{% trans "Any country" %}</option>
 						{% for country in all_filters.countries %}
 							<option {% if entries_filters.countries == country %}selected{%endif%} value="{{country.id}}">{{country.title}}</option>
 						{% endfor %}
@@ -59,7 +59,7 @@
 						<option {% if not entries_filters.topics %}selected{% endif %}  disabled>
 							{% trans "Topic" %}
 						</option>
-						<option value="None">{% trans "Any topic" %}</option>
+						<option value="">{% trans "Any topic" %}</option>
 						{% for topic in all_filters.topics %}
 							<option {% if entries_filters.topics == topic %}selected{%endif%} value="{{topic.id}}">{{topic.title}}</option>
 						{% endfor %}


### PR DESCRIPTION
Fixes #1004 

In this PR I've reworked the directory entry filtering code to process the user input through a Django form. There's a decent amount changed here, but everything follows from that one idea.

Processing `request.GET` through a Django form gets us some nice validation features "for free," including rejecting fields that contain the null character `\x00`.

Another nice thing is we can get `ModelChoiceField`, which does the querying of the model chosen by the user for us, meaning we can eliminate most of what the `filters_from_querydict` method was doing. I've replaced it with a simpler (IMO) mapping between form field names and filter arguments, which we can iterate over to construct our search parameters.

Overall, I've tried to improve the tests as well with the addition of some end-to-end tests of the directory page (rather than tests of the specific filtering methods).