### PR TITLE
Centralize npm audit checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,12 @@ jobs:
           pattern: ^package-lock.json$
 
       - run:
-          name: Check node dependencies for vulnerabilities
-          command: |
-            mkdir -p test-results
-            npm ci
-            npx npm-audit-plus --xml > test-results/audit.xml
+          name: Obtain misc resources
+          command: git clone --depth 1 https://github.com/freedomofpress/fpf-misc-resources.git
 
-      - store_test_results:
-          path: ~/securedrop.org/test-results/
+      - run:
+          name: Check node dependencies for vulnerabilities
+          command: npx audit-ci@^6 --config fpf-misc-resources/audit-ci/securedrop.org.json5
 
   build_dev:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   npm_audit:
     docker:
-      - image: cimg/node:18.14.2
+      - image: cimg/node:18.16
     working_directory: ~/securedrop.org
     steps:
       - checkout


### PR DESCRIPTION
This PR switches us from using `npm-audit-plus` to `audit-ci` with settings centralized in our misc. resources repo.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/326

See example failure here: https://github.com/freedomofpress/securedrop.org/pull/1016