### PR TITLE
Updates django to 3.2.19

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -303,9 +303,9 @@ decorator==5.1.1 \
     # via
     #   ipdb
     #   ipython
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements.txt
     #   django-anymail
@@ -1203,6 +1203,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -r requirements.txt
+    #   asttokens
     #   bleach
     #   google-auth
     #   html5lib
@@ -1521,10 +1522,11 @@ yarl==1.8.2 \
     # via vcrpy
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==67.6.0 \
-    --hash=sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077 \
-    --hash=sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2
+setuptools==67.7.2 \
+    --hash=sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b \
+    --hash=sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990
     # via
+    #   -r requirements.txt
     #   gunicorn
     #   pytablereader
     #   pytablewriter

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 https://github.com/freedomofpress/pshtt/zipball/65596ff08fa7bf0357b5af63da73e2dead91c304
 bleach>=4.1.0
-Django>=3.2.18,<3.3
+Django>=3.2.19,<3.3
 django-anymail[mailgun]>=1.4
 django-modelcluster
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -205,9 +205,9 @@ dataproperty==0.55.0 \
     #   pytablereader
     #   pytablewriter
     #   tabledata
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements.in
     #   django-anymail
@@ -889,6 +889,11 @@ willow==1.4.1 \
     --hash=sha256:fc4042696d090e75aef922fa1ed26d483c764f005b36cf523cf7c34e69d5dd7a
     # via wagtail
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==67.7.2 \
+    --hash=sha256:23aaf86b85ca52ceb801d32703f12d77517b2556af839621c641fca11287952b \
+    --hash=sha256:f104fa03692a2602fa0fec6c6a9e63b6c8a968de13e17c026957dd1f53d80990
+    # via
+    #   gunicorn
+    #   pytablereader
+    #   pytablewriter


### PR DESCRIPTION
Fixes vulnerability: https://pyup.io/v/55264/2ff/

It's mostly to do with form validation with file uploads, so I don't think it's super urgent and can be deployed in our usual deploy days.
