### PR TITLE
Updates requests dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1122,9 +1122,9 @@ pyyaml==6.0 \
     # via
     #   bandit
     #   vcrpy
-requests==2.28.2 \
-    --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
-    --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements.txt
     #   django-anymail

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ wagtail-metadata>=4.0.2
 wagtail-autocomplete>=0.8.1
 unittest-xml-reporting
 django-csp>=3.7
-requests>=2.25.1
+requests>=2.31.0
 urllib3>1.26.5
 wagtailmedia>=0.12.0
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -751,9 +751,9 @@ pytz==2022.7.1 \
     #   l18n
     #   pshtt
     #   typepy
-requests==2.28.2 \
-    --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
-    --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
I don't think our codebase is really vulnerable to this leak as such since we don't use Proxy Authorization headers I think. https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q