### PR TITLE
Do not install pip dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           name: Ensure we can run dev-env
           command: |
             make dev-init
-            docker-compose up -d
+            docker compose up -d
             echo "Polling with curl --silent until Django is up..."
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done
             make flake8
@@ -80,7 +80,7 @@ jobs:
           name: Yank docker logs
           command: |
             mkdir -p ~/dockercomposelogs || true
-            docker-compose logs > ~/dockercomposelogs/dev.log
+            docker compose logs > ~/dockercomposelogs/dev.log
           when: always
 
       - store_artifacts:
@@ -102,17 +102,17 @@ jobs:
       - run:
           name: Ensure we can run prod-env
           command: |
-            docker-compose -f prod-docker-compose.yaml build
-            docker-compose -f prod-docker-compose.yaml up -d
+            docker compose -f prod-docker-compose.yaml build
+            docker compose -f prod-docker-compose.yaml up -d
             docker run --rm --network securedroporg_app curlimages/curl:7.80.0 -4 --retry 24 --retry-delay 5 --retry-all-errors http://app:8000/health/ok/
-            docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata --no-download"
+            docker compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata --no-download"
           no_output_timeout: 5m
 
       - run:
           name: Yank docker logs
           command: |
             mkdir -p ~/dockercomposelogs || true
-            docker-compose -f prod-docker-compose.yaml logs > ~/dockercomposelogs/prod.log
+            docker compose -f prod-docker-compose.yaml logs > ~/dockercomposelogs/prod.log
           when: always
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:
-          version: 20.10.7
+          version: 20.10.18
 
       - run:
           name: Ensure we can run prod-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run:
           name: Install pip dependencies
-          command: pip install --require-hashes -r dev-requirements.txt
+          command: pip install --no-deps --require-hashes -r dev-requirements.txt
 
       - run:
           name: Check Python dependencies for CVEs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
 
   build_dev:
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2204:2023.04.2
     working_directory: ~/securedrop.org
     steps:
       - checkout

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -36,7 +36,7 @@ COPY devops/docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
 COPY --from=builder dev-requirements.txt /requirements.txt
-RUN pip install --require-hashes -r /requirements.txt
+RUN pip install --no-deps --require-hashes -r /requirements.txt
 
 ARG USERID
 RUN getent passwd "${USERID?USERID must be supplied}" || adduser --uid "${USERID}" --disabled-password --gecos "" gcorn

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -51,7 +51,7 @@ COPY --from=node-assets /src-files/ /django/
 RUN find /django -path /django/node_modules -prune -o -print -exec chown gcorn: '{}' \;
 
 WORKDIR /django
-RUN pip install --require-hashes -r /django/requirements.txt
+RUN pip install --no-deps --require-hashes -r /django/requirements.txt
 
 
 # Really not used in production. Needed for mapped named volume


### PR DESCRIPTION
This pull request makes it so that when we install pip packages on our docker containers, we use the `--no-deps` flag. This should address a problem where sometimes the pip install command would fail when new versions of a library was released.

See https://github.com/freedomofpress/pressfreedomtracker.us/pull/1487 for further information: same thing is happening here.

Fixes #1029 

This pull request also includes the CircleCI config updates to use the latest docker/ubuntu versions that were done on Freedom.Press (https://github.com/freedomofpress/freedom.press/pull/1327) and PFT (https://github.com/freedomofpress/pressfreedomtracker.us/pull/1676)