### PR TITLE
Remove npm dependency on `npm-audit-plus`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,6 @@ flake8: ## Runs flake8 linting in Python3 container.
 bandit: ## Runs bandit static code analysis in Python3 container.
 	@docker compose run --rm django ./scripts/bandit
 
-.PHONY: npm-audit
-npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities
-	@docker compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus'
-
 .PHONY: clean
 clean: ## clean out local developer assets
 	@rm -rvf ./node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "css-loader": "^6.7.1",
         "mini-css-extract-plugin": "^2.6.1",
-        "npm-audit-plus": "^0.2.0",
         "postcss": "^8.4.5",
         "postcss-loader": "^7.0.2",
         "sass": "^1.54.0",
@@ -3504,20 +3503,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm-audit-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/npm-audit-plus/-/npm-audit-plus-0.2.0.tgz",
-      "integrity": "sha512-0Og8en4ivNRoR/hSSBY+USZsGHJaOmLQ/LujuUX17KKwuUIIhrJUt+u9Hgh34t4X63NqkjZ6lhVwYfW9vVzSwQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "word-wrap": "^1.2.3",
-        "xmlbuilder": "^12.0.0"
-      },
-      "bin": {
-        "npm-audit-plus": "src/cli.js"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4690,24 +4675,6 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-12.0.1.tgz",
-      "integrity": "sha512-rRjf/JR+sEMqU2o6WEA+iR/YRIegH3P35eiQuCsT1YfZqOS+iu23azPq0igZjpBX+wa7D8gHd845kLPzow7IKg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "babel-plugin-add-module-exports": "^1.0.4",
     "css-loader": "^6.7.1",
     "mini-css-extract-plugin": "^2.6.1",
-    "npm-audit-plus": "^0.2.0",
     "postcss": "^8.4.5",
     "postcss-loader": "^7.0.2",
     "sass": "^1.54.0",


### PR DESCRIPTION
We are not using this anymore since we started using `audit-ci`, and also, it was affected by this vulnerability:

* https://github.com/advisories/GHSA-j8xg-fqg3-53r7