### PR TITLE
Fix null character handling in search queries

### DIFF
--- a/search/forms.py
+++ b/search/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class SearchForm(forms.Form):
+    query = forms.CharField(required=True)

--- a/search/tests/test_search.py
+++ b/search/tests/test_search.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from django.db.models import Func, Value
 from django.test import TestCase
 
@@ -23,3 +24,10 @@ class SearchTestCase(TestCase):
         self.assertTrue(results.filter(id=sd1.pk).exists())
         self.assertTrue(results.filter(id=sd2.pk).exists())
         self.assertFalse(results.filter(id=sd3.pk).exists())
+
+    def test_search_handles_null_characters(self):
+        query_with_nulls = '\x00'
+        response = self.client.get(
+            reverse('search'), {'query': query_with_nulls}
+        )
+        self.assertEqual(response.status_code, 200)

--- a/search/views.py
+++ b/search/views.py
@@ -6,16 +6,17 @@ from django.db.models import Func, F, TextField
 from django.shortcuts import render
 
 from search.models import SearchDocument
+from .forms import SearchForm
 
 
 def search(request):
-    search_query = request.GET.get('query', None)
     page = request.GET.get('page', 1)
+    form = SearchForm(request.GET)
 
     # Search
-    if search_query:
+    if form.is_valid():
         vector = F('search_vector')
-        query = SearchQuery(search_query)
+        query = SearchQuery(form.cleaned_data['query'])
         search_results = SearchDocument.objects.annotate(
             rank=SearchRank(vector, query),
             search=vector,
@@ -36,6 +37,6 @@ def search(request):
         search_results = paginator.page(paginator.num_pages)
 
     return render(request, 'search/search.html', {
-        'search_query': search_query,
+        'search_query': form.cleaned_data.get('query', ''),
         'search_results': search_results,
     })


### PR DESCRIPTION
This form replaces the "manual" processing of search queries with a django `Form` instance, which will automatically filter null characters. Similar to what was done to the directory page filters in #1011.

## Description

Fixes #1039 

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Without the changes here, requests such as to http://localhost:8000/search/?query=1%00%C0%A7%C0%A2%252527%252522 should raise an exception. You can try this out locally. This branch should replace that behavior with loading the page normally but with an empty search box and results.

### Post-deployment actions

None needed.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

