### PR TITLE
Fix tor detection logic in browser

### DIFF
--- a/client/tor/js/detect-tor.js
+++ b/client/tor/js/detect-tor.js
@@ -22,6 +22,9 @@ const is_tor_resource_loaded = async () => new Promise(resolve => {
 	}
 })
 
+const is_likely_mobile_browser = function () {
+	return window.navigator.userAgent.indexOf("Mobi") !== -1
+}
 
 const is_likely_tor_browser = async function () {
 	return (
@@ -38,8 +41,8 @@ const is_likely_tor_browser = async function () {
 	) || await is_tor_resource_loaded()
 }
 
-const is_likely_mobile_browser = function () {
-	return window.navigator.userAgent.indexOf("Mobi") !== -1
+const is_likely_desktop_tor_browser = async function () {
+	return !is_likely_mobile_browser() && await is_likely_tor_browser()
 }
 
 
@@ -58,8 +61,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 	const instances = document.getElementById('js-instances')
 	const body = document.body
 
-	if (await is_likely_tor_browser()) {
-		/* If the source is using Tor Browser, we want to encourage them to turn Tor
+	if (await is_likely_desktop_tor_browser()) {
+		/* If the source is using Tor Browser in desktop, we want to encourage them to turn Tor
 			Browser's Security Slider to "High", which enables various hardening
 			methods, including disabling Javascript. Since JS is disabled by turning
 			the Security Slider to "High", this code only runs if it set to another

--- a/client/tor/js/detect-tor.js
+++ b/client/tor/js/detect-tor.js
@@ -1,6 +1,5 @@
 // This user agent string matches Tor Browser 9 and 10 or Firefox Quantum (on desktop)
 const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64|Android( [0-9]{2})?; Mobile); rv:[0-9]{2,3}\.0\) Gecko\/20100101 Firefox\/([0-9]{2,3})\.0/
-const MOBILE_TOR_UA_REGEX = /Mozilla\/5\.0 \(Android( [0-9]{2})?; Mobile; rv:[0-9]{2,3}\.0\) Gecko\/(20100101|[0-9]{2}\.0) Firefox\/([0-9]{2,3})\.0/
 
 // Use Tor css resource loading to check whether it's Tor Browser
 const is_tor_resource_loaded = async () => new Promise(resolve => {
@@ -39,13 +38,6 @@ const is_likely_tor_browser = async function () {
 	) || await is_tor_resource_loaded()
 }
 
-const is_likely_mobile_tor_browser = async function () {
-	return (
-		window.navigator.userAgent.match(MOBILE_TOR_UA_REGEX) &&
-		new Date().getTimezoneOffset() == 0
-	) || await is_tor_resource_loaded()
-}
-
 const is_likely_mobile_browser = function () {
 	return window.navigator.userAgent.indexOf("Mobi") !== -1
 }
@@ -67,7 +59,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 	const body = document.body
 
 	if (await is_likely_tor_browser()) {
-		console.log("I am here")
 		/* If the source is using Tor Browser, we want to encourage them to turn Tor
 			Browser's Security Slider to "High", which enables various hardening
 			methods, including disabling Javascript. Since JS is disabled by turning
@@ -87,7 +78,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 			instances.classList.add('instances--tor-warning')
 		}
 
-		let torWarningClose = document.getElementById('js-tor-warning-close')
 		const closeUseTorBrowser = document.getElementById('js-tor-warning-close')
 
 		closeUseTorBrowser.addEventListener('click', () => {
@@ -101,7 +91,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 			sessionStorage.setItem('torWarningDismissed', '1')
 		})
 	} else if (is_likely_mobile_browser()) {
-		console.log("I am here")
 		let torWarning = document.getElementById('js-tor-mobile-warning')
 		torWarning.classList.remove('tor-warning--hidden')
 		torWarning.setAttribute('aria-hidden', 'false')

--- a/client/tor/js/detect-tor.js
+++ b/client/tor/js/detect-tor.js
@@ -1,6 +1,17 @@
 // This user agent string matches Tor Browser 9 and 10 or Firefox Quantum (on desktop)
-const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64|Android; Mobile); rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/
-const MOBILE_TOR_UA_REGEX = /Mozilla\/5\.0 \(Android; Mobile; rv:[0-9]{2}\.0\) Gecko\/20100101 Firefox\/([0-9]{2})\.0/
+const TBB_UA_REGEX = /Mozilla\/5\.0 \((Windows NT 10\.0|X11; Linux x86_64|Macintosh; Intel Mac OS X 10\.[0-9]{2}|Windows NT 10\.0; Win64; x64); rv:[0-9]{2,3}\.0\) Gecko\/20100101 Firefox\/([0-9]{2,3})\.0/
+const MOBILE_TOR_UA_REGEX = /Mozilla\/5\.0 \(Android( [0-9]{2})?; Mobile; rv:[0-9]{2,3}\.0\) Gecko\/(20100101|[0-9]{2}\.0) Firefox\/([0-9]{2,3})\.0/
+
+// Use Tor css resource loading to check whether it's Tor Browser
+let isTorResourceLoaded = false
+let css = document.createElement("link")
+css.href = "resource://torbutton-assets/aboutTor.css"
+css.type = "text/css"
+css.rel = "stylesheet"
+css.onload = function() {isTorResourceLoaded = true}
+document.head.appendChild(css)
+document.head.removeChild(css)
+console.log(isTorResourceLoaded)
 
 
 const is_likely_tor_browser = function () {
@@ -14,14 +25,16 @@ const is_likely_tor_browser = function () {
 		// implements letterboxing, such as Firefox configured with
 		// privacy.resistFingerprinting=true
 		window.screen.width == window.innerWidth &&
-		window.screen.height == window.innerHeight
+		window.screen.height == window.innerHeight &&
+		isTorResourceLoaded
 	)
 }
 
 const is_likely_mobile_tor_browser = function () {
 	return (
 		window.navigator.userAgent.match(MOBILE_TOR_UA_REGEX) &&
-		new Date().getTimezoneOffset() == 0
+		new Date().getTimezoneOffset() == 0 &&
+		isTorResourceLoaded
 	)
 }
 


### PR DESCRIPTION
## Description

Fixes #1034.

Changes proposed in this pull request:
Fixes detection of Tor browser logic. There are few different things that I have done in this PR that needs to be checked (though it just updates and fixes the detection logic):
- Adds `resource://` URL loading check to check for sure that it is a Tor Browser.
- Updates the Tor Browser User Agent regex
- Keeps both the previous checks and adds the resource URL check as a fallback to identify guaranteedly (for now) that it's a Tor Browser.
- I have removed the `is_likely_mobile_tor_browser` function since it was not being used in the logic. The JS code shows the same message for all mobile browsers irrespective of whether it's Tor, Chrome, Firefox or something else
- Adds a `is_like_desktop_tor_browser` function to ensure that the Tor Browser security level message is shown only in Desktop Tor browser.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
Since testing of this PR involves opening the website in Tor Browsers, the reviewer will probably need ngrok or something similar. Once you have local instance running and ngrok setup, open the forwarding URL in the various browsers to check the below scenario:
- Go to admin section. Go to Settings -> Tor Alert Settings, and update the information for "Tor not detected", "Tor settings too low" and "Tor mobile alert" 
- Open the URL in a desktop non-Tor browser (e.g. firefox, chrome). The information from "Tor not detected" settings should show
- Open the URL in Tor Browser desktop. The information from "Tor settings too low" should show in `safe` and `safer` levels.
- Open the URL in mobile chrome, and mobile tor browser. Both should show the information from "Tor mobile alert".

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader