### PR TITLE
Leave wagtail search backend on default configuration if possible

### DIFF
--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -168,9 +168,7 @@ else:
 try:
     es_host = os.environ.get('DJANGO_ES_HOST', 'disable')
 
-    if es_host == 'disable':
-        WAGTAILSEARCH_BACKENDS = {}
-    else:
+    if es_host != 'disable':
         WAGTAILSEARCH_BACKENDS = {
             'default': {
                 'BACKEND': 'wagtail.search.backends.elasticsearch2',


### PR DESCRIPTION
## Description

The settings variable `WAGTAILSEARCH_BACKENDS` is assigned to the database backend in the base settings file, but in this production file we are checking to see if ElasticSearch is enabled.  If it is (not the case, IMO) then we configure the backend, and otherwise reset the backends setting to `{}` -- I'm not sure how this actually affects the search feature on the sight, but there's no reason to do it.  We want the DB search backend in the default case, so let's leave it that way.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

This ideally either changes nothing, or fixes the search if it's broken. Right now, I'm not getting any results for any searches in the wagtail admin. I recommend testing the admin page/document search on staging. It should not raise any errors, and if it actually finds results, then that's a bonus!

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change
No frontend changes.