### PR TITLE
Only run `npm_audit` and `safety_check` jobs on develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,6 @@ jobs:
           name: Check Python dependencies for CVEs
           command: make safety
 
-      - run:
-          name: Update bandit to the latest version
-          command: pip install --upgrade bandit
-
-      - run:
-          name: Static code analysis for vulnerabilities
-          command: ./scripts/bandit
-
   npm_audit:
     docker:
       - image: cimg/node:20.6
@@ -62,16 +54,29 @@ jobs:
       - checkout
 
       - run:
-          name: Ensure we can run dev-env
+          name: Build and start dev environment
           command: |
             make dev-init
             docker compose up -d
             echo "Polling with curl --silent until Django is up..."
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done
-            make flake8
-            make dev-tests
-            make check-migrations
           no_output_timeout: 5m
+
+      - run:
+          name: Run flake8
+          command: make flake8
+
+      - run:
+          name: Validate migrations
+          command: make check-migrations
+
+      - run:
+          name: Static code analysis for vulnerabilities
+          command: docker compose exec django ./scripts/bandit
+
+      - run:
+          name: Run tests
+          command: make dev-tests
 
       - store_artifacts:
           path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
       - run:
           name: Static code analysis for vulnerabilities
-          command: docker compose exec django ./scripts/bandit
+          command: make bandit
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   npm_audit:
     docker:
-      - image: cimg/node:18.16
+      - image: cimg/node:20.6
     working_directory: ~/securedrop.org
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,16 @@ workflows:
   version: 2
   freedomdotpress_ci:
     jobs:
-      - safety_check
-      - npm_audit
+      - safety_check:
+          filters:
+            branches:
+              only:
+                - develop
+      - npm_audit:
+          filters:
+            branches:
+              only:
+                - develop
       - build_dev
       - build_prod
   nightly:


### PR DESCRIPTION
This is intended to stop these from running on non-deployment pull requests, and only trigger them when we are merging from `develop` into `prod`.

## Description

Part of https://github.com/freedomofpress/fpf-www-projects/issues/360

Applies CircleCI filters to the `npm_audit` and `safety_check` jobs so they will only run on the `develop` branch. This is to stop them from running on all PRs except for ones we make to deploy the site from `develop` into `prod`.

I've also done a little housekeeping:
1. Updated the version of node used for the audit check
2. Tried to make the `build_dev` check easier to read by breaking it into multiple steps.
3. Moved `bandit` into the `build_dev` check so it still runs on every PR.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Things to verify about this change:
1. This PR should not have the npm audit or safety check jobs appear on it.
4. After this is merged, the PR to deploy the site again _should_ have those jobs on it.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader


