### PR TITLE
Updates to python 3.9.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
@@ -66,7 +66,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -74,7 +74,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 .PHONY: pip-upgrade
 pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 # in requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file requirements.txt requirements.in && \
@@ -83,7 +83,7 @@ pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 .PHONY: pip-dev-upgrade
 pip-dev-upgrade: ## Uses pip-compile to update all dev requirements that are not pinned
 # in dev-requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
-FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243 AS python-base
+# sha256 for python:3.9.18-slim-bookworm on linux/amd64 as of 2023-09-15
+FROM python:3.9-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0 AS python-base
 RUN apt-get update && \
     apt-get install -y \
        gcc \

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
     libxslt-dev \
     libssl-dev \
     libz-dev \
-    netcat \
+    netcat-traditional \
     python3-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
     libxml2-dev \
     libxslt-dev \
     libz-dev \
-    netcat \
+    netcat-traditional \
     python3-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -20,8 +20,8 @@ RUN cd /src-files && ( npm install && npm run build )
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="securedrop.org"
 
-# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
-FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243 AS python-base
+# sha256 for python:3.9.18-slim-bookworm on linux/amd64 as of 2023-09-15
+FROM python:3.9-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0 AS python-base
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
## Description

Refs https://github.com/freedomofpress/fpf-www-projects/issues/344

Updates to python 3.9.18 which includes a security update to ssl https://github.com/python/cpython/releases/tag/v3.9.18
Also updates the image to use debian Bookworm instead of debian Buster

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Dependency update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
Build locally and see the python backend codes work and tests pass.
