### PR TITLE
Remove npm audit job requirement that package-lock.json changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ jobs:
     working_directory: ~/securedrop.org
     steps:
       - checkout
-      - check-changed-files-or-halt:
-          pattern: ^package-lock.json$
-
       - run:
           name: Obtain misc resources
           command: git clone --depth 1 https://github.com/freedomofpress/fpf-misc-resources.git


### PR DESCRIPTION
## Description

Follow up on #1055, related to https://github.com/freedomofpress/fpf-www-projects/issues/360

### Changes proposed in this pull request:

This removes the check on package-lock.json that will cause the npm audit job to only run if that file was changed.  This was needed to prevent npm audit from running on PRs when the node packages were not updated.  But now we are not running it on _any_ PRs, so we can remove that condition.  It ought to always run when we want it run.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

This can be tested by verifying that the npm audit check runs on all deployment PRs even if the code being deployed does not update the package-lock.json file.

### Post-deployment actions

None

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:
No changes.
### If you made changes to contact form

No changes.

### If you made changes to scanner

No changes.

### If it's a major change

No major changes.

### If you made any frontend change

No frontend changes.
