### PR TITLE
Gitpython 3.1.37

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,43 +50,8 @@ compile-pip-dependencies:
 	docker build --target=requirements-artifacts -f ./devops/docker/DevDjangoDockerfile --output type=local,dest=$(DIR) .
 
 .PHONY: pip-update
-pip-update: ## Uses pip-compile to update requirements.txt for upgrading a specific package
-# It is critical that we run pip-compile via the same Python version
-# that we're generating requirements for, otherwise the versions may
-# be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
-		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
-    pip install pip-tools && \
-		pip-compile --generate-hashes --no-header --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
-		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
-
-
-.PHONY: pip-dev-update
-pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading a specific package
-# It is critical that we run pip-compile via the same Python version
-# that we're generating requirements for, otherwise the versions may
-# be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
-		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
-    pip install pip-tools && \
-		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
-
-.PHONY: pip-upgrade
-pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
-# in requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
-		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
-    pip install pip-tools && \
-		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file requirements.txt requirements.in && \
-		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'
-
-.PHONY: pip-dev-upgrade
-pip-dev-upgrade: ## Uses pip-compile to update all dev requirements that are not pinned
-# in dev-requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
-		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
-    pip install pip-tools && \
-		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'
+pip-update:
+	docker build --build-arg="PIP_COMPILE_ARGS=--upgrade-package=$(PACKAGE)" --target=requirements-artifacts -f ./devops/docker/DevDjangoDockerfile --output type=local,dest=$(DIR) .
 
 .PHONY: lint
 lint: flake8

--- a/README.rst
+++ b/README.rst
@@ -169,14 +169,6 @@ There are separate commands to upgrade a package without changing the ``requirem
 
 will update the package named ``package-name`` to the latest version allowed by the constraints in ``requirements.in`` and compile a new ``dev-requirements.txt`` and ``requirements.txt`` based on that version.
 
-If the package appears only in ``dev-requirements.in``, then you must use this command:
-
-.. code:: bash
-
-    make pip-dev-update PACKAGE=package-name
-
-which will update the package named ``package-name`` to the latest version allowed by the constraints in ``requirements.in`` and compile a new ``dev-requirements.txt``.
-
 Advanced Actions Against the Database
 -------------------------------------
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -329,9 +329,9 @@ gitdb==4.0.10 \
     --hash=sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a \
     --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
     # via gitpython
-gitpython==3.1.35 \
-    --hash=sha256:9cbefbd1789a5fe9bcf621bb34d3f441f3a90c8461d377f84eda73e721d9b06b \
-    --hash=sha256:c19b4292d7a1d3c0f653858db273ff8a6614100d1eb1528b014ec97286193c09
+gitpython==3.1.37 \
+    --hash=sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33 \
+    --hash=sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54
     # via bandit
 google-api-core==2.11.0 \
     --hash=sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22 \

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -6,10 +6,12 @@ RUN apt-get update && \
     libpq-dev
 
 FROM python-base AS builder
+ARG PIP_COMPILE_ARGS
 RUN pip install -U pip pip-tools wheel
 COPY dev-requirements.in requirements.in dev-requirements.txt requirements.txt ./
 COPY devops/docker/pip-compile.sh /usr/local/bin
-RUN pip-compile.sh
+# Pass given pip compile arguments through to the pip compile script
+RUN pip-compile.sh $PIP_COMPILE_ARGS
 
 # This build target extracts the requirements.txt files from the
 # previous stage and is intented to be used with

--- a/devops/docker/pip-compile.sh
+++ b/devops/docker/pip-compile.sh
@@ -7,6 +7,7 @@
 
 set -e
 
-pip-compile --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file requirements.txt requirements.in
-
-pip-compile --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file dev-requirements.txt dev-requirements.in
+# Pass arguments given to this script through to the `pip-compile`
+# commands.  Intended to be used with `--upgrade-package` and related.
+pip-compile "$@" --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file requirements.txt requirements.in
+pip-compile "$@" --generate-hashes --no-header --allow-unsafe --resolver=backtracking --output-file dev-requirements.txt dev-requirements.in


### PR DESCRIPTION
## Description

Updates gitpython to the latest version (fixing GHSA-cwvm-v4w8-q58c).

Also updates the makefile command `pip-update` to use the newer requirements-generating containers. Running (for example)

```
make pip-update PACKAGE=gitpython
```
will now use the development dockerfile builder stage and generally be faster and nicer (or at least I think it's nicer).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


