### PR TITLE
Adds robots.txt and sitemap.xml

### DIFF
--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -72,3 +72,10 @@ def get_site_name():
 @register.filter
 def document_view_url(value):
     return reverse('view_document', args=[value.id, value.filename])
+
+
+@register.simple_tag(takes_context=True)
+def get_absolute_url(context, view_name, *args, **kwargs):
+    return context['request'].build_absolute_uri(
+        reverse(view_name, args=args, kwargs=kwargs)
+    )

--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'django.contrib.postgres',
+    'django.contrib.sitemaps',
 
     'build',
 ]

--- a/securedrop/templates/robots.txt
+++ b/securedrop/templates/robots.txt
@@ -1,0 +1,6 @@
+{% load common_tags %}
+User-agent: *
+Disallow:
+Crawl-delay: 10
+
+Sitemap: {% get_absolute_url 'sitemap' %}

--- a/securedrop/urls.py
+++ b/securedrop/urls.py
@@ -8,6 +8,7 @@ from django.views.generic import TemplateView, RedirectView
 from search import views as search_views
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 
 from common.views import view_document, health_ok, health_version
@@ -33,6 +34,8 @@ urlpatterns = [
     re_path(r'^document/view/(\d+)/(.*)$', view_document, name='view_document'),
     path('health/ok/', health_ok),
     path('health/version/', health_version),
+    path('sitemap.xml', sitemap, name='sitemap'),
+    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
 
     path('search/', search_views.search, name='search'),
 


### PR DESCRIPTION
## Description

Resolves #1075.

Changes proposed in this pull request:
Adds a robots.txt which allows all the URL to all bots (or rather disallows nothing). Also adds a sitemap.xml and adds the sitemap link to robots.txt.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
- Check /robots.txt shows the content that it should.
- Check /sitemap.xml shows the sitemap correctly.


PS: Unlike in PFT, I have not add any cache purging for sitemap specifically since it seems like whenever a new page is created or deleted in securedrop.org, all cache is purged. Let me know what you think @chigby 
