### PR TITLE
Update wagtail autocomplete to version 0.11.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1047,9 +1047,9 @@ wagtail==4.1.9 \
     #   wagtail-factories
     #   wagtail-metadata
     #   wagtailmedia
-wagtail-autocomplete==0.9.0 \
-    --hash=sha256:b64828d35f370453c84bc4094174872822798e54414f5fb9fc8a43c2a6c3e727 \
-    --hash=sha256:d85789543308d344447656725b9aac8d1c4c6fb271221a3340008a3c9f2ab6fa
+wagtail-autocomplete==0.11.0 \
+    --hash=sha256:11479000aae7532376048d0ff75585d9bebc8fdd09bad88b28f770032a362d11 \
+    --hash=sha256:b2ba0f5c8a0e43cdc124a9503d91e9815fb0251a1431d52db5868306ab935059
     # via -r requirements.txt
 wagtail-factories==4.0.0 \
     --hash=sha256:3e39ec1cc13b61c6e467f1bf223ce2d134e823fa9fe4dc7e32d0222cc8d350ec \

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ tinycss2
 wagtail>=4.1.9,<4.2
 wagtail-factories
 wagtail-metadata>=4.0.2
-wagtail-autocomplete>=0.8.1
+wagtail-autocomplete>=0.11.0
 unittest-xml-reporting
 django-csp>=3.7
 # urllib3 2.x doesn't with vcrpy below Python 3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -592,9 +592,9 @@ wagtail==4.1.9 \
     #   wagtail-factories
     #   wagtail-metadata
     #   wagtailmedia
-wagtail-autocomplete==0.9.0 \
-    --hash=sha256:b64828d35f370453c84bc4094174872822798e54414f5fb9fc8a43c2a6c3e727 \
-    --hash=sha256:d85789543308d344447656725b9aac8d1c4c6fb271221a3340008a3c9f2ab6fa
+wagtail-autocomplete==0.11.0 \
+    --hash=sha256:11479000aae7532376048d0ff75585d9bebc8fdd09bad88b28f770032a362d11 \
+    --hash=sha256:b2ba0f5c8a0e43cdc124a9503d91e9815fb0251a1431d52db5868306ab935059
     # via -r requirements.in
 wagtail-factories==4.0.0 \
     --hash=sha256:3e39ec1cc13b61c6e467f1bf223ce2d134e823fa9fe4dc7e32d0222cc8d350ec \


### PR DESCRIPTION
## Description

Updates wagtail autocomplete to version 0.11.0

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

1. The autocomplete feature should still work and use the latest version of the package.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:
No changes.
### If you made changes to contact form

No changes.

### If you made changes to scanner

No changes.
### If it's a major change

Not a major change.

### If you made any frontend change

Not a front-end change.