### PR TITLE
Augment production log data

### DIFF
--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -19,11 +19,7 @@ except ImportError:
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS').split(' ')
-
-
-MIDDLEWARE += [  # noqa: F405
-    'common.middleware.RequestLogMiddleware',
-]
+MIDDLEWARE.insert(3, 'common.middleware.RequestLogMiddleware')  # noqa: F405
 
 
 structlog.configure(

--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -45,8 +45,9 @@ structlog.configure(
 )
 
 pre_chain = [
-    # Add the log level and a timestamp to the event_dict if the log entry
-    # is not from structlog.
+    # Add the context vars, log level and a timestamp to the
+    # event_dict if the log entry is not from structlog.
+    structlog.contextvars.merge_contextvars,
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
 ]


### PR DESCRIPTION
## Description

A part of https://github.com/freedomofpress/fpf-www-projects/issues/350

While doing research and testing for the above ticket, I noticed some places where our production log configuration could be improved.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
In production mode (i.e. with `docker compose -f prod-docker-compose.yaml` or by copying the production log settings into the development settings file), the following should be happen on this branch (but not on develop):

1. Wagtail redirects should correctly be logged as 301 status.
2. Django log messages, such as CSRF violations, should contain the complete request/response data (which is seen from our own loggers but not currently on django's loggers). This can be tested by, say, making a post request without a CSRF cookie.

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
