### PR TITLE
Updates frame-src and connect-src with media subdomain

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -292,11 +292,10 @@ CSP_STYLE_SRC_ATTR = (
     "'unsafe-hashes'",
     "'sha256-ZdHxw9eWtnxUb3mk6tBS+gIiVUPE3pGM470keHPDFlE='",
 )
-CSP_FRAME_SRC = ("'self'",)
-CSP_CONNECT_SRC = (
+CSP_CONNECT_SRC = [
     "'self'",
     "analytics.freedom.press",
-)
+]
 CSP_EXCLUDE_URL_PREFIXES = ("/admin", )
 
 # Need to be lists for now so that CSP configuration can add to them.
@@ -306,6 +305,7 @@ CSP_IMG_SRC = [
     "analytics.freedom.press",
 ]
 CSP_OBJECT_SRC = ["'self'"]
+CSP_FRAME_SRC = ["'self'"]
 CSP_MEDIA_SRC = ["'self'"]
 
 # This will be used to evaluate Google Storage media support in staging
@@ -317,6 +317,8 @@ if os.environ.get("DJANGO_CSP_IMG_HOSTS"):
 # default-src, set an explicit object-source
 if os.environ.get("DJANGO_CSP_OBJ_HOSTS"):
     CSP_OBJECT_SRC.extend(os.environ["DJANGO_CSP_OBJ_HOSTS"].split())
+    CSP_FRAME_SRC.extend(os.environ["DJANGO_CSP_OBJ_HOSTS"].split())
+    CSP_CONNECT_SRC.extend(os.environ["DJANGO_CSP_OBJ_HOSTS"].split())
 
 # Report URI must be a string, not a tuple.
 CSP_REPORT_URI = os.environ.get('DJANGO_CSP_REPORT_URI',


### PR DESCRIPTION
## Description

It was reported that PDF embeds are not working in pages like https://securedrop.org/news/piloting-securedrop-workstation-qubes-os/. On testing, I found out that they worked fine in firefox but not in chrome. The reasoning in chrome seemed to be that the `media.` subdomain is missing from the `frame-src` CSP directive. However on investigating why it works in firefox, seems  like the redirects to our media subdomain is handled differently in the different browsers. In firefox, the initiator of the redirected link is considered to be the embed object, and hence the CSP directive checked is `object-src`, but in chrome, it still checks under the `frame-src` directive. We had already updated our setting before to add `media.` subdomains to our `object-src`.

So in this PR, I modified the code such that the `frame-src` and `connect-src` are both updated with the `DJANGO_CSP_OBJ_HOSTS` environment variable. In all the other web repo, we have been updating both `object-src` and `connect-src`. It seems like we are using pdf.js in the other repo which sends an XHRequest and hence falls under the `connect-src` directive. But in SDO, we are using Pdfoject, which creates an embed object whose redirect seems to be handled differently in different browser.

Hopefully that makes sense. We have to test if all of the above are true in staging, since locally I don't have a redirect for media.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
I don't think there is a good way to test it locally. So I think we might have to test it on staging and see if the `frame-src` CSP directive has `https://staging-media.securedrop.org`

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
