### PR TITLE
Logging warning number

### DIFF
--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -1,27 +1,12 @@
-import contextlib
 from unittest import mock
 
-import structlog
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from wagtail.models import Page
 
 from common.middleware import RequestLogMiddleware
 
-
-@contextlib.contextmanager
-def capture_logs_with_contextvars():
-    """Modified version of structlog.testing.capture_logs that captures
-    data bound to structlog's loggers with ``bind_contextvars``.
-
-    """
-    cap = structlog.testing.LogCapture()
-    old_processors = structlog.get_config()['processors']
-    try:
-        structlog.configure(processors=[structlog.contextvars.merge_contextvars, cap])
-        yield cap.entries
-    finally:
-        structlog.configure(processors=old_processors)
+from .utils import capture_logs_with_contextvars
 
 
 class RequestLogTestCase(TestCase):

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -1,3 +1,6 @@
+import contextlib
+
+import structlog
 from wagtail.models import Site
 
 from directory.models import DirectorySettings
@@ -8,3 +11,18 @@ def turn_on_instance_scanning():
     settings = DirectorySettings.for_site(site)
     settings.show_scan_results = True
     settings.save()
+
+
+@contextlib.contextmanager
+def capture_logs_with_contextvars():
+    """Modified version of structlog.testing.capture_logs that captures
+    data bound to structlog's loggers with ``bind_contextvars``.
+
+    """
+    cap = structlog.testing.LogCapture()
+    old_processors = structlog.get_config()['processors']
+    try:
+        structlog.configure(processors=[structlog.contextvars.merge_contextvars, cap])
+        yield cap.entries
+    finally:
+        structlog.configure(processors=old_processors)

--- a/github/event_codes.py
+++ b/github/event_codes.py
@@ -1,0 +1,26 @@
+import enum
+
+
+EventCode = enum.IntEnum(
+    value="EventCode",
+    # New names should only be added to the *end* of this list.
+    # Adding a new name will implicitly change the integer value of
+    # the names that come after it, which will change how these are
+    # aggregated in our log files.
+    #
+    # For the same reason, once an event code has been released into
+    # production, it should not be removed from the list.
+    names=[
+        'SignatureNotSha1',
+        'PostDataMissing',
+        'InvalidSignature',
+        'UnsupportedGithubEvent',
+        'UnsupportedAction',
+        'ReleaseAttributeMissing',
+    ],
+    # This start value is designed to be unique for the "github" app.
+    # Other apps should use a different start value that does not
+    # reasonably conflict with this value (e.g. 2000, 3000, and so
+    # on).
+    start=1000,
+)

--- a/github/tests/test_receive_hook.py
+++ b/github/tests/test_receive_hook.py
@@ -130,6 +130,16 @@ class TestReceiveHook(TestCase):
         )
         self.assertEqual(Release.objects.count(), 0)
 
+    @override_settings(GITHUB_HOOK_SECRET_KEY=b'test')
+    def test_incorrect_signature_type(self):
+        self._post_hook(
+            json_file_name='valid_release_hook.json',
+            secret=b'test',
+            payload_digest_func=lambda payload: payload,
+            signature='md5=39382',
+        )
+        self.assertEqual(Release.objects.count(), 0)
+
     @override_settings(GITHUB_HOOK_SECRET_KEY=b'WRONG SECRET KEY')
     def test_incorrect_secret(self):
         self._post_hook(


### PR DESCRIPTION
## Description

Part of https://github.com/freedomofpress/fpf-www-projects/issues

Changes proposed in this pull request:

1. Brings our use of structlog in line with the standard idioms for using this library (structured context vars).
2. Adds the concept of an "event code" -- a number that we can use to aggregate the same event on Kibana reports. A given warning message should correspond to one error number.
3. The error numbers are arbitrary, but they need to be unique and dealing with numbers directly is kind of fiddly and prone to typos, so I've made them `Enums` that apply to a given Django app. This way they have human-readable names but correspond to a number in the code. Though this does require a small amount of discipline in defining them, due to the fact that we don't want to change them after they're live in production or our data will also change (see code comments for the implications of this).
4. Adds these error codes to the warnings for this site, all of which occur in the github views.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Try poking the github view. You may have to slightly edit the code and/or carefully construct a valid-enough request to get some warnings logged. These log lines should include the correct error codes.

Also, not about testing but let me know what you think about how this system is designed. What is good, what maybe needs to be changed? If we like it, we can apply it to other sites, too, which have a lot more logged warnings than this one does.

### Post-deployment actions
None.
## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
