### PR TITLE
Adds optional CSRF_TRUSTED_ORIGINS settings to production settings file

### DIFF
--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -129,6 +129,13 @@ DATABASES = {
 #
 STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
 
+# Adds CSRF_TRUSTED_ORIGINS to ensure that the origins we trust
+# are used rather than it checking with the Host header
+try:
+    CSRF_TRUSTED_ORIGINS = os.environ['DJANGO_CSRF_TRUSTED_ORIGINS'].split(' ')
+except KeyError:
+    pass
+
 if os.environ.get('GS_BUCKET_NAME'):
     INSTALLED_APPS.append('storages')  # noqa: F405
 


### PR DESCRIPTION
## Description

After the latest deploy, seems like form submissions are not working. This is because since Django 4.x, for CSRF verification, the Origin information is also verified. Previously, it only verified Referrer header with the ALLOWED_HOSTS, but that was changed (probably [in this commit](https://github.com/django/django/commit/2411b8b5eb65fe3d7bcc1ee1f59e2433520c7df6)) to also add origin check if a `Origin` header is present in the request.

Now, ideally, the `CSRF_TRUSTED_ORIGINS` settings should not be required at all. Based on the code that [verifies the origin ](https://github.com/django/django/blob/3f6d939c62efd967f548c27a265748cc2cc47ca5/django/middleware/csrf.py#L270-L294), if the `HOST` header along with the scheme matches the `ORIGIN` header then that should just pass the test. Which is why, it seems to be passing locally. But I think it's failing in staging and production, maybe because django is somehow not computing the request scheme as `https://`, maybe because of cloudflare or something that I am not 100% sure.

But in case the `HOST` and scheme doesn't match the `ORIGIN` header, it checks in the list presented by `CSRF_TRUSTED_ORIGINS`. So I am adding that settings in this PR. This settings is already present in the other web repo.



## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
I don't think  it's possible to test it locally. We might have to just test it in staging once the necessary changes are also made in the infra side.

### Post-deployment actions

Not a post-deployment action but some infrastructure changes are needed. CC @freedomofpress/fpf-infra : We need to [now add scheme](https://docs.djangoproject.com/en/5.0/releases/4.0/#csrf-trusted-origins-changes) also to this env var. So it should be `https://securedrop.org`.
