### PR TITLE
Update the admin for `DirectoryEntry` pages to use correct URLs for scan result links

### DIFF
--- a/blog/tests/test_rss_feed.py
+++ b/blog/tests/test_rss_feed.py
@@ -1,31 +1,14 @@
-import unittest
 import feedparser
-from django.test import Client
+from django.test import Client, TestCase
 from blog.tests.factories import BlogIndexPageFactory, BlogPageFactory
-from home.tests.factories import HomePageFactory
-from wagtail.models import Page, Site
+from wagtail.models import Site
 
 
-class RSSTest(unittest.TestCase):
+class RSSTest(TestCase):
     def setUp(self):
-        Page.objects.filter(slug='home').delete()
-        home_page = HomePageFactory.build(
-            description_header="Share and accept documents securely.",
-            slug="home"
-        )
-
-        root_page = Page.objects.get(title='Root')
-        root_page.add_child(instance=home_page)
-
-        Site.objects.create(
-            site_name='SecureDrop.org (Dev)',
-            hostname='localhost',
-            port='8000',
-            root_page=home_page,
-            is_default_site=True
-        )
+        site = Site.objects.get()
         self.blog_index = BlogIndexPageFactory(
-            parent=home_page,
+            parent=site.root_page,
             search_description="Search me!"
         )
         self.blog_index.save()

--- a/common/management/commands/tests/test_createdevdata.py
+++ b/common/management/commands/tests/test_createdevdata.py
@@ -2,12 +2,12 @@ import os
 
 from django.contrib.auth.models import User
 from django.core import management
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.urls import reverse
 from wagtail.models import Page
 
 
-class CreateDevDataTestCase(TestCase):
+class CreateDevDataTestCase(TransactionTestCase):
     def test_createdevdata_works(self):
         """The createdevdata command successfully creates functional pages
 

--- a/directory/templates/directory/admin_scan_result_help.html
+++ b/directory/templates/directory/admin_scan_result_help.html
@@ -6,7 +6,8 @@
 		{% if self.instance.pk %}
 			{% if self.instance.get_live_result %}
 				{% with latest=self.instance.get_live_result %}
-					<a class="button button-small button-secondary" href="{% url 'directory_scanresult_viewset_inspect' instance_pk=latest.pk %}">
+
+					<a class="button button-small button-secondary" href="{% url 'scanresult:inspect' pk=latest.pk %}">
 						Latest live result
 					</a>
 					<dl>
@@ -21,7 +22,7 @@
 
 			<hr>
 
-			<a class="button button-small button-secondary" href="{% url 'directory_scanresult_viewset_index' %}?securedrop__page_ptr_id__exact={{ self.instance.pk }}">All scan results</a>
+			<a class="button button-small button-secondary" href="{% url 'scanresult:index' %}?securedrop={{ self.instance.pk }}">All scan results</a>
 		{% else %}
 			No scans available.
 		{% endif %}

--- a/directory/wagtail_hooks.py
+++ b/directory/wagtail_hooks.py
@@ -26,6 +26,7 @@ class ScanResultAdmin(ModelViewSet):
         'result_last_seen',
         'grade',
         'live',
+        'securedrop',
     )
     search_fields = ('landing_page_url', 'securedrop__title')
     inspect_view_enabled = True


### PR DESCRIPTION
## Description

Fixes #1099

Changes proposed in this pull request:

1. Fix a misconfiguration of the test suite where the tests for the `createdevdata` command were not being run as part of the entire suite. Among other things, these tests exercise the wagtail admin's editing functionality for `DirectoryEntry` pages, which would have revealed the error described in #1099. 
1a. As part of this fix, I've updated a few older tests that had the potential to fail due to inter-test side effects because they were not using Django's `TestCase` and relied too much on a certain database state.
2. I've updated the directory entry Scan Result help panel to use the correct URLs for the links to related scan result data.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

1. Ensure editing a Directory Entry page works without errors.
2. Ensure the "Latest Live Result" and the "All Scan Results" buttons at the bottom of "Content" tab on that page link to the correct pages in the admin. See screenshot below.

![image](https://github.com/freedomofpress/securedrop.org/assets/561931/a560a09d-36aa-4991-b7eb-0b0c12979176)


### Post-deployment actions

None.

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

None

### If you made changes to contact form

None

### If you made changes to scanner

No scanner changes.

### If it's a major change

Not a major change.

