### PR TITLE
Update gunicorn to version 22.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -436,9 +436,9 @@ googleapis-common-protos==1.58.0 \
     # via
     #   -r requirements.txt
     #   google-api-core
-gunicorn==20.1.0 \
-    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+gunicorn==22.0.0 \
+    --hash=sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9 \
+    --hash=sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
     # via -r requirements.txt
 html5lib==1.1 \
     --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
@@ -666,11 +666,13 @@ openpyxl==3.1.1 \
     # via
     #   -r requirements.txt
     #   wagtail
-packaging==23.0 \
-    --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
-    --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
+packaging==24.0 \
+    --hash=sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5 \
+    --hash=sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9
     # via
+    #   -r requirements.txt
     #   dparse
+    #   gunicorn
     #   safety
 parso==0.8.3 \
     --hash=sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0 \
@@ -1352,7 +1354,4 @@ yarl==1.9.4 \
 setuptools==68.2.2 \
     --hash=sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87 \
     --hash=sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
-    # via
-    #   -r requirements.txt
-    #   gunicorn
-    #   safety
+    # via safety

--- a/directory/tests/test_filters.py
+++ b/directory/tests/test_filters.py
@@ -164,11 +164,17 @@ class DirectoryCountryFilterTest(TestCase):
         cls.azerbaijan = CountryFactory(title='Azerbaijan')
 
         # set up instances that are children of the directory and have those countries
-        cls.mexico_instance = DirectoryEntryFactory(parent=cls.directory)
+        cls.mexico_instance = DirectoryEntryFactory(
+            parent=cls.directory,
+            countries=0,
+        )
         cls.mexico_instance.countries.add(cls.mexico)
         cls.mexico_instance.save()
 
-        cls.azerbaijan_instance = DirectoryEntryFactory(parent=cls.directory)
+        cls.azerbaijan_instance = DirectoryEntryFactory(
+            parent=cls.directory,
+            countries=0,
+        )
         cls.azerbaijan_instance.countries.add(cls.azerbaijan)
         cls.azerbaijan_instance.save()
         cls.country_filter = {'countries': cls.mexico}

--- a/requirements.txt
+++ b/requirements.txt
@@ -296,9 +296,9 @@ googleapis-common-protos==1.58.0 \
     --hash=sha256:c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df \
     --hash=sha256:ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a
     # via google-api-core
-gunicorn==20.1.0 \
-    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+gunicorn==22.0.0 \
+    --hash=sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9 \
+    --hash=sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
     # via -r requirements.in
 html5lib==1.1 \
     --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
@@ -414,6 +414,10 @@ openpyxl==3.1.1 \
     --hash=sha256:a0266e033e65f33ee697254b66116a5793c15fc92daf64711080000df4cfe0a8 \
     --hash=sha256:f06d44e2c973781068bce5ecf860a09bcdb1c7f5ce1facd5e9aa82c92c93ae72
     # via wagtail
+packaging==24.0 \
+    --hash=sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5 \
+    --hash=sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9
+    # via gunicorn
 pillow==10.3.0 \
     --hash=sha256:048ad577748b9fa4a99a0548c64f2cb8d672d5bf2e643a739ac8faff1164238c \
     --hash=sha256:048eeade4c33fdf7e08da40ef402e748df113fd0b4584e32c4af74fe78baaeb2 \
@@ -709,9 +713,3 @@ willow[heif]==1.6.2 \
     # via
     #   wagtail
     #   willow
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.2 \
-    --hash=sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87 \
-    --hash=sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
-    # via gunicorn


### PR DESCRIPTION
## Description
Fixes vulnerability GHSA-w3h3-4rj7-4ph4

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

