### PR TITLE
Ensure request log middleware higher than common middleware

### DIFF
--- a/securedrop/settings/production.py
+++ b/securedrop/settings/production.py
@@ -19,7 +19,7 @@ except ImportError:
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS').split(' ')
-MIDDLEWARE.insert(3, 'common.middleware.RequestLogMiddleware')  # noqa: F405
+MIDDLEWARE.insert(1, 'common.middleware.RequestLogMiddleware')  # noqa: F405
 
 
 structlog.configure(


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1097

Django's common middleware is what ensures requests without a trailing slash in the URL are redirected (with a 301 status) to URLs with a trailing slash.  But until this happens, the request is handled as a 404, so it will be logged that way unless the common middleware is run prior to the log entry being generated.  So this change moves the log middleware above the common middleware to ensure this happens.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Locally, you can add 

```
MIDDLEWARE.insert(1, 'common.middleware.RequestLogMiddleware')  
```

To the development settings (`securedrop/settings/dev.py`). With this enabled, the `develop` branch should log requests to, for example, `/health/ok` as a 404. With this change, they should be logged as a 301.

### Post-deployment actions
None.
## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

