### PR TITLE
Version file error handling

### DIFF
--- a/devops/docker/django-start.sh
+++ b/devops/docker/django-start.sh
@@ -28,7 +28,7 @@ django_start() {
         ./manage.py collectstatic -c --noinput
     fi
     if [ "${DEPLOY_ENV}" == "dev" ]; then
-        ./devops/scripts/version-file.sh
+        ./devops/scripts/version-file.sh || echo "WARNING: version file creation failed"
         ./manage.py runserver 0.0.0.0:8000
     else
         gunicorn -c /etc/gunicorn/gunicorn.py "${DJANGO_APP_NAME?}.wsgi"

--- a/devops/scripts/version-file.sh
+++ b/devops/scripts/version-file.sh
@@ -6,6 +6,13 @@
 
 set -e
 
+handle_error() {
+    echo "Error: line $1, exit code $2"
+    exit 1
+}
+
+trap 'handle_error $LINENO $?' ERR
+
 short_version_out="${DJANGO_SHORT_VERSION_FILE:-/deploy/version-short.txt}"
 full_version_out="${DJANGO_FULL_VERSION_FILE:-/deploy/version-full.txt}"
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

Copied over the changes from https://github.com/freedomofpress/freedom.press/pull/1474 over into this repo.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

The dev env should start up, and even if there is an error in the `version-file.sh` script, the site should start and be accessible. See original PR for additional ways to test this.

### Post-deployment actions

None

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader