### PR TITLE
Bulk scan error handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 networks:
   app:
 services:

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -92,7 +92,10 @@ def bulk_scan(securedrops: 'DirectoryEntryQuerySet') -> None:
             tldextract.extract(d).registered_domain
             for d in entry.permitted_domains_for_assets
         ]
-        current_result = perform_scan(entry.landing_page_url, permitted_domains)
+        try:
+            current_result = perform_scan(entry.landing_page_url, permitted_domains)
+        except Exception:
+            continue
 
         # This is usually handled by Result.save, but since we're doing a
         # bulk save, we need to do it here

--- a/scanner/tests/scans_vcr/bulk-scan-error-handling.yaml
+++ b/scanner/tests/scans_vcr/bulk-scan-error-handling.yaml
@@ -1,0 +1,618 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - SecureDrop Landing Page Scanner 0.1.0
+    method: GET
+    uri: https://www.2600.com/securedrop
+  response:
+    body:
+      string: '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+
+        <html><head>
+
+        <title>301 Moved Permanently</title>
+
+        </head><body>
+
+        <h1>Moved Permanently</h1>
+
+        <p>The document has moved <a href="https://www.2600.com/securedrop/">here</a>.</p>
+
+        </body></html>
+
+        '
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '240'
+      Content-Type:
+      - text/html; charset=iso-8859-1
+      Date:
+      - Wed, 29 May 2024 14:37:05 GMT
+      Location:
+      - https://www.2600.com/securedrop/
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - SecureDrop Landing Page Scanner 0.1.0
+    method: GET
+    uri: https://www.2600.com/securedrop/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5VXa2/bNhT93l/B+Us3wLGLbk2HwvHQotgaoG22Nl2xjxR1ZTGmSJWkrCq/fueS
+        UiwnewIF6vBxH+eeey61+aZ0Kg4tiTo2Zvvo0Yb/F0ba3cWC7GKLBZLl9pEQm4aiFKqWPlC8WHSx
+        OvsR+7wTdTS0fXr+5Ik4Ex9JdZ5ee9du1nkjnTHa7oUnc7EIcTAUaqK4ELWnalpZqRBGg0F53UYR
+        vMJm+h1WN9jcrPNfHOg6B/ZoU7hyQJylPghlZAgXi6KL0VnBLhdClxcL/nUW3RmHuOBk4EOOzusY
+        2/Bive77fsX7K+WaRUpms5awu4bhU/ON1PZMORvJIsaUbol0z7StXPY3W9yRJa9V3hxd10+3n2sZ
+        hQ4ztH5CRk9T+jjRbo8bfExa/HN2aHQcRHTOiMp5ceM6b6XRIfKJUvQ1fhoqjOvJh5V4iWURcEjR
+        UgyuEwp2ukACS2LuwIYojZFRA7XoRleuC2YQoSvgVIAmXYN8A+/zded30urbdGclrrrTaNjJzAHu
+        eFKkDzSGIxoZAYs0OfCMF7wB+6azWmFX9DrWx1AEAy4ViLBZtxNME5Chdp0pxaXYW9eLggAOjZFH
+        bXd33kSsvet29d/Dfu1E610kFRkwP0O9r4nBY3PH20uhUxkpBICTPch0FYgJ62JCQgpLsXd+D9RE
+        SQcNANI5rgfJoJF5gSUvFZWikGrPiCX/nmBTl2w8DitxiUqB9stktu0KoxVwqvTkIMOZXYRccsDm
+        nVnlBBm69KMz+Uf6w+jtayfeX10LqXBvzkoBRqRAqGmNG8g/DpMvFAIX/5uVjNt9Q9CSspee/o+l
+        KZ7aNfRPkVz99d1jKbg4aGenNMhRZrbB8hKysefyUAYWVZJYKrz0A5dPyWoe72bNSN6x8RcY1XEl
+        3oCGXNzLqX8qDYVLxWkQlNzhj3/l4pUFT7iGgIjraMFKRMoNOtV+SiZFyaFxiGO0S1Cwt8bJMvkd
+        mzxldo1Tr7zrA/l5O7Xbt7Kzqn5wRvyuA5K43/coIZr1S3fS658+vOVwkpQedXAVnV85m8Ti22uY
+        L7XnJktjAQ2khvP+5vnzgx9qNdTnO/fs+Xn9dVA3tz/0X437ITw70KHE4f576Zv+Ng7PbtztUI42
+        vxM/OwPZS5Fzpr5THGHugUojfxSf4x/1p0UJGEm0bQl23tOjqUan4HxmBWB7jdxTZmGlfYi5xiHA
+        X5bZXgPnSfDkhJFyaGPZ0Eq8o8Z5fUuJKpdVvuN15IVUtCXLQQB0HGJJSMcNKTXl2gGsRRbM5ZTd
+        4wMl2YTUgRwwgCsNO4BcfApjnJPvlLLe2Swy2k5qPkNliRlP2OQB4ym0ABFkrbxr0smZyi8TVl2b
+        KVaWmhGHXN1heU+qT8ZRz/pHBgGeiPe9Fnjv8rTjXpJFcKaLPCZ2nfQS83fMLtGMNdrNBHslmGYF
+        wBO95KF5Kuyt1wephpTCUeTlMURmJbdaWVOuQzLVQqMji+spNf6YDVcYoBbxxVSXFhH7qU4oJcBP
+        ehNaUtAXhZZMwdUIxGTdOdKJQ2YRw4D1pxOc8TCwzMaEawnuWGHDgPnQZAm7ltoEBlqjowvn4lhF
+        KT59fCUCstin7HE35GEB9JDcIQERUyjcHa4SdCCoH05xUKeZv0zSlqczGk8cpOlkgRV+LpYST0ZZ
+        uI5VMUzAnuVZqrkw6HyMOAYkDa5RsKgcCdJIVWtL6aC2B2cOvMWRjTuQINwhoENRrcRUBzwTu+IY
+        Qso78MTIOozigyrcC0eo84hi0++may8zL7LYQRCd2bOUI15WNW6fhPEDKkAlreGwC6rlQaepYbml
+        6Wv01DCDPSBFF9ndSnygXWekx2IDMYNOchyJoknjJ6VNkwrNRaWWTPSeisCSwaZbF/PzA0YqI3d5
+        ahy5jF5gydox1LiQ+Rxr1t5cnX58tTyMvNG7Oo7h5oZHqQNeJH5EbDYnkvRABXZMytCBdseMTkHi
+        6fAiNegbCBFu/oaOBp0TMplIED2NZh2n+PiMEQ5MvP98pS+dbvlxmlseY66q0jzX9sHIytpc5EZD
+        rvzwQnRhfG1mZ0hjZv7IEfThZ7oLJbUqeQ4oPeYCEp36aHZniRrgsSEczuP1ww85Tfz2OdwNwaPb
+        xOyJfsyb8SsDPTiVaBpZ/Bi8U10xfbmghWA8vW24lZlqxu1YMjy/LysozlJc/oqoYD2HBPEIrNs4
+        mh+alU4NnJsXvvgUFcPRdC5RrjB/1/gmY1sl/R1AXN86iBTLxmndX+dHcamD6pCxIblPbPfzbxes
+        LPmuzUXBLA8sEKcfANN32Xr8/FvnD9g/AUsu3vvRDgAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1743'
+      Content-Security-Policy:
+      - default-src 'self'
+      Content-Type:
+      - text/html
+      Date:
+      - Wed, 29 May 2024 14:37:06 GMT
+      ETag:
+      - '"ed1-5c371fd0d07af-gzip"'
+      Expires:
+      - '-1'
+      Last-Modified:
+      - Sat, 29 May 2021 06:20:27 GMT
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=16070400;
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - master-only
+      X-XSS-Protection:
+      - 1; mode=block
+      orig_req_proto:
+      - https
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - SecureDrop Landing Page Scanner 0.1.0
+    method: GET
+    uri: https://www.forbes.com/fdc/securedrop.html
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+VZTXPbNhq+91dgeWgvkmjZjp11Je9mk8m0O9kmkziHPWlAAhJRkQALgJKZTv/7
+        Pi9ASZRkeatmpofdTOKEEvF+fzwP8s2k8FV5/w3Dr0klPWeaV3KarJRc18b6hOVGe6n9NFkr4Yup
+        kCuVy2F4GCitvOLl0OW8lNPxoOKPqmqq7XPjpA0PPMP32iSdIq98KZnysqqtqadJIbkolZbJ/Q9m
+        zR4M++wke2tsJh37JPPGyjd4j03ScPDYWiFdblXtldFJT+zex1s/egKVY1wzU0s9dKaxuWTrQjmo
+        yEqzlpa5JquUcxDLXOtgLvMF96ySQnFm7IJr9YWTVsdKtdyanEMoXGfeMBesL1vG81zWngmTNxXC
+        6djcmgraBQJcVY1WOfdQr3yBD41uK9M4Fo1yo03ceglaynZtrHB9f3ef7ZLW92fQE+1V7QZdjDvx
+        vSKgtEjr22liFncOiZpRWfSKISZnz669M40te28X3tfuLk3X6/VoHtI6gtfpXORpDJCAvhFV4mmJ
+        quKLvgUbmaqTqKpFEBqSk3LnpHdpVDYbX15cPNKP0c/14rSK/516YXox5N7b4bYQfv2VimfUc/G3
+        305HoqkFylHMvNrL+okD3HqVl/KubrJSuULaU6nnucyMWcbkhzr4LxJ54wvTF3fi/Xl2x+t6pkRP
+        8/jy6uav1y+vxxcvL16+uNg7GYecR7t5ae9ybvsHXVNV3LazktuFnMW6O545m8PUHT2tf48l94y2
+        MMN6J54dec/I+b+u1v0EdrNht1D+hGHh27qfxbXMQiUcF4qWazf7Q+N6twjCtN6fudiXS4bVMk0c
+        WsTnjWcK3Z6wwsr5NEnTw8E459jcRo/wY2PlTga6p5RDb5q8GD4vZm++4hi9vRm0QzyH47MXt48v
+        bke13k7b51Q59UW6aXJ7+Xh7edr+36c4CDlT8Xh8/Yg/X6u6E3Ou8msov/565VHM08oBSAwhDOzk
+        XY+EFR2L5Yz9TJvl2UO7hZ4el5nzbSmxISSAZZQyV1gcaZoC8VmXipyb9I1Z69Jw4frgIHfbXZEZ
+        0XZt9pfhkP0A8AisNhx2nxGYlDY+BFgr1IrlJRDBNLFmPVRaY0Ptvg/v9AS9MwuzlUZfhhf4tq8O
+        QAwmeZRd4lzCPC0NoOWZk+X8QEsQBJzCnM0BejtQdNinsc5J2ratnAfKzHu53ZqV8p6jKTztgpD2
+        oxCBXS8MTmxSU4w35hdSDOnzbh19koCmHQR/swWtn53Six4kn6TFuNNoOhYRnCzV/SaLAeMqDRfK
+        EvBZAt5bliERSHgEwdvY9svQGwtA+bPM/QhAuxfXrOR6mcTJpw1hd8jRBkNPWkuJPS1lgmiN2MOB
+        DbALxgSA7hxhdjCBPuuogTsHRAzygqiCBTDC2/gdPEkKJYQEP5CWiNEomaRwPkR8E4n3sPHIc4rK
+        mivPgBfCl6Qm0gvHW5KOMarhPpGPAuoyCSkSYYwYSwzolMZbNcgFhNUcBCVImhvyiBKlNNyhj7gQ
+        lrzLuL1jkwzdMclCoNB6HSDvAXHEfoR5YfQkze7D28YeHLr5YnQ5L4pb/oufr027EiUXV/pR35TI
+        2ePl8sa3bXvlan99pfWL619uypXOlejJPYrT22B3sJfqxTbB+ZASR9UIQqQ0rK0C5RoRSbQOlAl1
+        lUm2UCuEg8KGdICsxFgSFcOXYGOC5KCrEIN8CUGRexUSD5QChKeGMqQ2ELOu8q0kEgw1o11aJ+mm
+        1GNf1QjR/U+IszElI308c6ZsPLG+RcMtB3+WrKWqCjFWvgV37KgYHmJFAgt7FERLVqLwPTIfz9RW
+        rXgecxwBAQkI9ddxVrBYHOICwDtwziCqthzhQ0nDciQxrbs2Ddb+2zTBUiKpECNrWIniAX2qYbcl
+        xd+tJAPCVAtNRIC5WuZqTisEXkFHgZIDhadc9UgyDKcmGrH3dkBCdkoQlRKSSVjXRFSfHakO3PmB
+        qxKMNPYZWMKWIrPPn/7BHHxZhpShASlLIZ7k4iqEwwdTqErMnMmVtC3cCsz9Kf8fDmK8i+uaeqo5
+        mHIDbE2GKEMgqDsuPGJtkYPCYPb4LpBaenDyJWU3XpPsalBypxA5lKJHYhDQUIUIZPDDSshUqFtw
+        A9TDj6h+LLFBEBtIVY4ynyvWKaBbC9GpCJEIlzTWlE/5+sawn94/bMZb7/IDcyUoxyVMaVppv3Mb
+        +WeJicE6lFSAUq25lWeJ2lhUGLRv5+uTAt4/7Q4ur7oMUE6w8E2uQvWGaxWYOIjXNFQqIZ4oG46P
+        Mgu6R1nL+fzA4tjiu8Uan+coz7MhRm//xvPDgBj2gUjYGa5Gb3aoguZ7cv8t/fU9u7y4vNqMpn+F
+        S6h3716P2CtMwI9qUaBlPkpaRFIgbCTlAOXs/NjupyesArFww7UFlj/CScG8BmMuQp6NH3TiCUe6
+        Bbh5G+Nkmdwfbfs6rG6pMTmG1cKOMPhR/uGO4G+1EtO4ny7G52CAV+J1YWj60crf38gbzzfb+TSy
+        o+upbvrGu6lDcPehG82fAM8k3ep9jTYUVIXbvAP8+ECfhnZ/bbTAbSt21NdoIZ9oWGByPu0T1NCX
+        WK5nqKkwu70hLCGloMnW3YJQEpP7ACU/O/a2+/IMwUdXhsSxXYoLG4mljCuuYayO9Chw/zSZY698
+        1y1nqNxDRdj/FiDKjXD5uP03VeY5xfixE8K+ZR+QznihfE54T0Qhul7bY+c79PIhYL6PxlTn+79j
+        OYGPhHY8x+lXAkvYKydPq56kTY8zhH7cH1C9xwlg6m7mAtLsOGAa/wfjPwicJrnKGAAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Age:
+      - '5616'
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2103'
+      Content-Security-Policy:
+      - default-src 'none'; img-src https://i.forbesimg.com; style-src 'unsafe-inline'
+      Date:
+      - Wed, 29 May 2024 14:37:06 GMT
+      Pragma:
+      - no-cache
+      Referrer-policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - x-malcolm, X-is-EU, X-is-CN, X-is-US-DPA, X-is-US, X-Device, x-backend, canary,
+        X-Is-Ad-Light, is-vwo-enabled
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-City-Code:
+      - burlington
+      X-Content-Type-Options:
+      - nosniff
+      X-Country-Code:
+      - US
+      X-Download-Options:
+      - noopen
+      X-Fastly-Backend:
+      - 24YyrkkiTBhSwXWzJgvwW6--F_GCP_NGINX
+      X-Fastly-X-is-CN:
+      - 'false'
+      X-Fastly-X-is-US:
+      - 'true'
+      X-Fastly-X-is-US-DPA:
+      - 'false'
+      X-FastlyTTL:
+      - '31536000.000'
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - master-only
+      X-Postal-Code:
+      - 05408
+      X-Region:
+      - VT
+      X-Served-By:
+      - cache-iad-kiad7000107-IAD
+      X-Timer:
+      - S1716993426.380020,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+      alt-svc:
+      - h3=":443";ma=86400,h3-29=":443";ma=86400,h3-27=":443";ma=86400
+      content-encoding:
+      - gzip
+      content-type:
+      - text/html
+      etag:
+      - W/"63b4b0a8-18ca"
+      last-modified:
+      - Tue, 03 Jan 2023 22:48:08 GMT
+      server:
+      - istio-envoy
+      state:
+      - HIT-CLUSTER
+      x-device:
+      - pc
+      x-envoy-upstream-service-time:
+      - '140'
+      x-fastly-server-hint:
+      - cacheable
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - SecureDrop Landing Page Scanner 0.1.0
+    method: GET
+    uri: https://www.cnn.com/tips/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA+2d3XYbR5Ln7/spaujTPe4ZAERV4VOm2C3TVsvTlFtjyXLbe/boFIECAQlfRgGk
+        qJk5Zy5m32Bv9nbv9jX2UfpJ9vePrC98kARpS63utWxWFbIyIyMjIiMjI7Mif3X0D/1Zb3k1j73h
+        cjI+/tWRu3n8OxrGUf/4V3rUv6N/qFbzH9sPLhPXyq9L/z4lIf+ZZ/E+zdLyJCVY0U9z0O5dLcua
+        3oFYSjlMAbikT+xWStoB8Z9cVjKlT7/+1LM6AOuSXHll8z75tautlKTmreFo8Greod3dpYBYLq93
+        wr0E0pI2ISoxRYWqau5fjmO5vGW0i9FEWNqvDYhK+9TeUHfxL2s1b2v2tpYWV/5fH1rSP10P0TGx
+        AMdTCeKvKylIwXJ1cxeDPrFfG5xRyfTFtRDTNpjsZBBzOgF8vdUFLmsASzga/3MpcOgatlZUaK9D
+        dHi7UmWY5ZqsfIqcy1+6bkM0gTWqQK/iXxliuXz6vJa0gaO9S0VMyHzi/unRsUG12A93dY8uybF8
+        s9XuHdxxoFUg/5dCSkGaFBVJrnHk3YaYwZJ68FIJt5t7oVQvFZZ/SrGyJOtkXu1Tk721XqjXOVpb
+        D1YPOUSs7J8BXC/lbegeZXE6JSuU3bPCpfKZKiIp0wXQLIe4/VCtFso1f3u0HC3H8fHzeNr3Im85
+        mnvLmXfy9ddeVdejQ/c6z54/HE3iZeT1htEiiZcPD1bLQbVzUMB3r6fRJH54sJidzZbJgdebTZfx
+        lMyjaT9+W/EGs/F4dnlNofPZ7HwcU7BUbjqLFr3h6CK+pozhWsq/1ahryvXjpLcYzZej2bRU+sns
+        UrRIaGIs3AejPtiPorGXLGeLK9Eq8SLINomW8ULpl6PlUFT7y3/+r8R7PVstptF4lCyT2jX1vomv
+        LmeLfpk0AlrxLocUo/WQJ17wexxHb7jlICcVVVPxvhtGy+TRfF7xno/OqaziPVvEy+WV94fZrM/z
+        6CLqXZH4h2cVL572FlfWxvw57nvxJBpZsdlyNn1qz8/j3moRf7GYAXaegYims+nVZLQEWqL39tS7
+        OgO99Oc1bUwgQy8ukRXEr8sa9zZYsEquy7o6o96N3Nfkjebz8agXKXNVArkXLhej+HI+W5Sl73LU
+        Xw4f9uOLUS+u2o+KN5qOJBHVpBeN44d+xZuQMllNSgnR2/WEVRIv7HV0RpHpDIIOF6Ppm+pyVh2M
+        lqRc047BbIGkVfvxcqvly3gcz4ezqeCVShedFVPK+9M8nv5hEc2HXlkRuI46h9vxYnn18GB2/mC1
+        GJdoNFwu58mDw8PLy8tabzqt9WYTlMI8OSxVtAOITLwSlGixHPXG2x13reJktIxf7cGitULjmWhf
+        qiqevvr2+S3ISeeVityuKNaq/PD6Yq360SQ6L2OfcajXhzsph7hP47fLw340OYwSVHRy6HfqnXro
+        d/y6363yvjqaXsTJcnSO+kqqYmm1Fy361WSFKFSXcZTEtdfz85spabg8iMbljvIIjTj1LuMIsT7X
+        oLJA9wxRodHS9OUg7s8WkTecjfuJt5qTYyFNBDZjpLCsLNcF+HHUY0CYvblRfgdnD6I+vbCsVFvd
+        et1vhN3mDW1Rufn81ahfEotOvVH3Qz9odLqlkutIvUDpo/69HUi50W/pMjyQcJdg//56PVgu8WAN
+        oXazGzT9Ei7lYTYr1lvEEQPU3eoS50slktVkEi2uXo2jxXn8ygnc7sE9q/WvLJTrtP5QUjlGbyO8
+        44cHPQ2QjDJozuEiHjw8yDrljWqzKJ8MGWx6q6U3wtLIYEzi/ijKuu8gYuCZTWtcygJQgNA4FzOK
+        rHrDahlKhsmGejisxYejyflhWKsfno9nZ9H4cDJKeoebYGrzaVkHFNJf1Jwsr8ZxMoxjtID0/sOD
+        pXRPL6ETOmrweCiVIy1T48fv4m6/P2i1wqB+NmhE8SDsRmW5LmpxllkKtjSUH477//w6gVaFWP5b
+        XkrW8sHvzd58uzx44OXcSHpDLJ7abHF+UClMZZfdRizyfh1fJo/S4aqyDlIOCpodC+T2mLGR2fWI
+        B95/W4NhdV3Dkp+msf1W1/T1Ohrvr75G+EGr832rbo2Y/329rQe5QQ1//oYt6U3R1CShN1tNJcqd
+        MNho9Hx1xixjGC94u94F1uX6T4vzaDp6Z4bwwToMy2iGF4TTwLTj9Xh2PttZw3otX8k4+dPZa2zU
+        HVAsr+xL6sk6QTSZ52ZLsgS9nqmKvFlV60imhrbRMoBmjAPSr4fX5BjGo/OhyNeqrwmQiv/HWsp/
+        rEM4iFZLVPPOhh/8PlMZv5D2PqTdkIPtkXKDFUxVp18yA19e/WnwTCbwzfL+XXxmudahmMD8Hquq
+        JIHbNd8oEn0M5mdppzM4gSxqP6jWgw2RP1DWE9lj8R4Zn876o8Eoyxk0gFf1wy2QJWcFbfg5vRTr
+        lDpI52yfz/pXUOuLmXc1W3nD6CJOHUWzBb6AKXYtHpnCCZK7TDJvyO+872JvNhhgJCfxRbyQoyS6
+        SuRbgTJMDPAQFK4NvCXKv4jPVxif4yueNBf3ktUZ5knCJB5HyBmG0lnci5hLM88gSy8WDpFn9qo3
+        XU1wTOBGwW8TTaezJTmS+QxXDXWCdWni4wkj8+XUvEdT7ObJFbgCCf8T2XGHvcBkYYo+W4371OlN
+        sQ7Qx8shnpBJjEJlirMcxlfyEPXixdRLrpJlPBn18J3MmOFPEsFbjiYxbZG36Gwxi/qeabcemDB3
+        YBJW814MoeEsWQJnMo/HWBnAVdXyPqGCaOkSb48aJDR6s4XcagtJlvM7sayymuCgMv2uVkI3HFa9
+        2GBTHF8dc8Kxgyii4FAAyThJIA8epiSG9C8yh9cgjvtnUe+NF53NoHYyw983FFISgiS69GZT+aBU
+        ETd5BSqe2CFm5mXlsqh5n8fcxSWYLQiC9008icUk16jpDFrSyL43SowAY5wc0Mt8S/AVsl2q8RA8
+        wTeVOCQcT5bRm9jrxzg3+sJpiNdugglModRjZZmnNCfHZJUIjWhqrIZ5oI1lCaNAZzYbI2AwM4F6
+        /I7eWF7adOlh1DJvzRxeoh0iKL8SJUbT3njVJ++DvLAKXg5plzVTorNEct4YPiJVykoeTTCde3Fw
+        Ze9BBUIvvAgn1wUa7zOI6xBJaXIZn0mULvEmCW+5b+A8NTr5+8zrjxI8TEoZoH+MaiZAxlT0UqSp
+        N/2hN56t+jRqIb9W8pkRO7qYjdSWrNKeWR9GIOf/SjxZ/w5vw1PGA35FeROFjjmj0n7oZPvxAg7M
+        JtYZEHX8lMjdY4waUIGC3qePnz3+rVMTCR0BecHRBTTqOF9BGsSWPoSPGilgHOCVdb3UQemwzjjO
+        utKXhsk3ToukeJls4WWYjugmpkPUCxw9a9Jv+inGjJiGDRz9R1PndhOKlC/0HY10eayDpp1f+OXd
+        BXec92Y6uxQdjfLqOerNiJA5RWu0f+HaWsB1ZquySjxIT320mf+WKkyx7nD0ep/i6P2tpNyLLp3a
+        gFr4ksfSHdIZ5n8XC8hYTR3CADS2Ja598v1Ksy0jk5G//Of/RPWqO/G+RAvXTEEVik4G6Q6juWhb
+        MX2HmxzTzrnILePKrEJPICElxK55f4zjOXDlNqUPWBdXt3RyhAKVCltIP4nfjiMTBIfBH8/RlEmn
+        UwX9EXUvvZm62uUIv5X3PB1psi5C19VQZV01a89TxMv5nCrel9PRuYmMdM1j/O4ncpZDCGkX5AHF
+        wygxM/GAeI4H8Vvc9GLvBr64dFOS/UEwa973KTujcZKCWBT+dti8Xt4RAjecHNCJeOUkJer3GWtn
+        +PkL5SZ3PEIrJ1ofbwFu7oyfHtmtk6mPzyaTldwTS8ZLLVKsUPVfuva6XA9ssPl96j6ke2b4ZWBQ
+        a7gWJZ2/hy8sFljLAOyZKdTzmHs98D5vfH7i+X7Y8VpffNH2Pv+87nuduv/IC5rdhldvdFpeo/W4
+        7flftj/32p3OifcH0C/VdorXEHFQ/0chuK7vpasb2Q3hibwB+kRa2xEr0koSIoEaM8PC2CZWug7k
+        lj6gDA4aDYD2YjzAl54sFytUrLooIoLcO+FCn2se47JKCGcaG5F2t87iMO7NxhJk5F++e+upWUW2
+        hEOvkYWA2pwylpX6iurPO4v186iH7gVz10sxSRLTilSaVtifgUwi20sj8Y6uiMYoDUKuq5S1sDCK
+        rQt5CWtF0EJCAyJ5MktNMQYUJogNOmgBmVla66JqN0I7neD6PhUuSoKlroXquUIMB9FqTNdJMRfS
+        1ktRdVnXRZlacTeYlHsyOmowOkcHiRYT9bgkLjHqpo6Qj9n0COPoRq8oUyPrytYZHKJFL+3PqBzG
+        LoeL2ep8CAbOas3GyFL3tkVK7+WMoZMGv9G2FlT6i8vReMTCDo800xg8ZxVsiImF5GI2zKNR33v+
+        1VNeLTBLvjZ79YH3z773aavR+q0XdtvVVrvetN6R0nF3z8hWAPOlQEnkZu9wQ1ySjspFH1gTeTqP
+        qbItadbQJ0FJ+5haBFv6mIxok5yl0IhsA7nC4dwVS6DI6llMInYfbXyBaKu7gt7sUuJ3duU9Ra1n
+        PcVUI28wCjI3vyr9asoocr6IsC5dr9FAoBZKiJktMUgirxM5RzSu5eOWk1FEotyXmCuJlcW6KcYP
+        VgXSHaMUwXyE2E7hGuxfYKNrAhTLGrSROHbqhZbBQlZWaf0GfA3nu5X0vWUz4+9HK50Zgt5u+Xye
+        LyYzJGfryk5GixldarNCduwVZxsxDYDoMsakAmwJPltmd0o5FzzrwpqV0d0KB5c0Z1Ef8xsYqekB
+        bGaOs8hs8Uz6kErGAqcXqXB2lghXp6S+epaNgU4GTRXLVGQywPwIYLjGNiVvh3YsRt4SZgURaBY1
+        FkaZxN2Ur01rpGydZU/LvpMmd921AAVystrT9HSuIaLQMjPtHXlFVuaPwp1OSFsNUzf3WF65CaCG
+        Mpt7ZhqwqOWB93LEjF80ZNSWl0/OdOubbjuHUZgu6sZVBgVTFnTssaa9apReoktyVnzuZjG1ymm0
+        0jphxqI03cpcRtSJJS5TDJzpTlNVXTmZzd2ses645axch4ZU2bffnFIZ2QUxs4bOosUDth4u5yxp
+        /zgZDS4H7Vbw42B51Z8vLoOof3beHibB5M1qGvWabxfvwt5Z82yVRIPx61G4eB01x6N+jaUeZAl0
+        UkAyjRITtz4L6TWGTJel8ti2uOykiVkmK+Y6KBLtHlkX65TJUrZmyxiXBqMFo3MhMhUbXhhsxjIn
+        UhcIdt6PK6kmJv9MympoWcyp0btUmrN0I2s62YFEkn3PpoajKQpvGCPZojdjP44TXAMYXJq9IYb5
+        LhRsU3Ks5o6zhXGat4h52DNcGtirZmq+WES5AWtNqaJ+sXrsJT0QW5qWoMxtwoSlEw2wz3JnUdmI
+        dcQeI6/WF0RLs+HkMMmEdl5UXfH6symKm3mdTdM1DDOnYINOLhepbmBQgx22gWdAD6l5n35lM0FS
+        +sx5mQzAMuhFF9L+jVQYl1hM4kVmgeW0Zp7Km/LECemns5lEuLpqv/WeapIhxwZMufIu2VyjxuzG
+        SLpTbue+Rqol7rhpXwWY3TjtZGJl0uLAO75pvOzHl9H4jVH7bPbW+C8IlneIUYkuxDsxH9Ns8RVD
+        Re4oHHcYN9KmdF3j1HL2wHsBof/yX//DPEBflbYRhHXvyarPspz3PZYNQ+fjsRf4rKgxBVq8qXhf
+        f4+TnsX4b9k3g/p5jrdKenngPZrQCXpR7nctnPJHh24JsFjnyzNph7D3OrqIXI5kfQ1+beXQFiSL
+        rKVVw4vIPFjeQ2vMv/+792//8VlRw1rlR4fFDuWjM9yi3qj/8EAPJXhH/dGFpWPtlJLld87B6sdR
+        cnHuvZ2Mp4lbLE632FyGUqiHAVQ6JMeBy/LgrfwtuzL63W730N4e0IFYh314AN9snvggOktm49Uy
+        /swWSB7UP3PLIDxcoMTPMFKXVw+Goz6awvxF8P7qAU6U+DN4b67Jqsy6ZfIAWSN1oznWCsz9pGCN
+        krJ/R8nV5ExTJGiU7hJ4roH8wJND9/PZ24cHda/utRr8f8DgqN1VB0Fj/pZFY1uuSX8dH80jpqxA
+        edqqV/xmLehVg5pfqde61UYtrPi1ZrVVa3Fv94Jao+rXGpVGLaiGpDVrPu98FQjIEFKgXeG52qZg
+        UGt7Bkpvq8oaAqoDCO49yoWVepVlx2al6W48+726KubPV4XcBad5EgSVIFQdqtXv1DqVNrl8UFW+
+        Fki1KoKue7PW8gATkiEgWygsK101y6dJQKb+NvcWOLECUGtckEaBphpGxq4yV3zQEHQwqAZcwVrX
+        HgVBi2JNA6Wm1WuB11M7GkBo8rotJJWvDc2orVsJaXeX952qL5ryIEC0E0CdFJBwCnpC1loKMSrN
+        ii9YzV6gX7QJmlb9lgDqKaS5NJVyTUEyaI2TZouffle4dPTU5inl7MHx0aG4zc1Jz+2iNTj7qVLV
+        NDl5QovFnTp0hOZcw4sGjITwYjTCU7H/hkGz1n0ZdmrtYbV9AdnCITeETA1tQwXoVxVzRGEYLjbB
+        GeguqQkqLbGnFl5A+qHEUfRvUGuDotRv98ZFc9ip+WNIJvjUA32DJ80WXARDuCUhD6vhS3J5J80u
+        UKEmIE2WXIPuQUsWQFhHSel5/27aBMNGDQ3GDPZEP4Jap9viR7OuB/12L5tB8XzSDGt+nVblL+05
+        LchzBvG0aYKTgedHVwUF3kFo1Qvw+fOpD+mzFydwRYjkCT78yaDouZNCOOVHXjGliqakEHJsAZ8/
+        n6AF1pril5qi57wp/KA3uKacQqm1H3m2H7ynDfREp4UYIg+dThu6ktLpdiyl022QgrCyyY2Ebq3V
+        aCoBFeT76DvELQjSMmGrTQqKxm8pS7PWDJSAmqh3ldCoNevUI3mr+ySchqiHbhewCDL3UgobQFzK
+        SZaH0i4FUlgh4KcJ1CgoecJJ6OAVKQGazbIIiPDPE7J6TrOUAhepkYbamOF7AoWabaUgR606YNAv
+        fj1tdFtw0U9hs0kOMDBCnTCotFsuxYdAZAFvnDCiJdaKK9NqiridWtBtk3AK/mEApejClqAG5QmC
+        sfM3eKiA3gtCU7hD8o7wOkFdhmHQRr2y81AQglrLB638N5pCzMkKiDctX1RNQYoRawn6HdSLDOXf
+        1ootufrhHmoDS4t5TjViSfJyY3QPfETqQD4vec/iR8mceds3cm4+PHj7dNT/nj/mzuwcOz5ipYoJ
+        wMMD2RoH9lxdrGTQyAiZ9ftkyS0BJCCkMY0wuGhIkJqyfhazN+T+5PHjx9kvt08bQ6LW6RwcpuVd
+        LS6brApwhNLtRusUdvuBF6J4O9DN9xhnG8EpI2CHRGwVlw0TttbodmnYO8E8PL/DaOVI9RUT2A1C
+        haEXhnsSKqcCPd5vefWTZi1sd716tRbWWx5DQ7dZY+Mq6NOgIECcGZMCDyEPPPX0Jg54xmAq9IJ2
+        LaBomqr2IXcuOz/QLwaEnAVolRFx6l6AmdDBrS8jqh2CCAZLowFw+khLIyMvSem0pRCbrdC9EPk6
+        zYDyKfrvHLMzzok9G4wXlfe1BzQbZS9UMXoFIFrXtEN/B8fekZms3hEWNYsN7Ijv23rgW//hQbP+
+        6wPvigfd3wZZAg8UJUmmrIP/ar10lc2LWPTL2Vw+m3mVpYHZwjXIpJFZlH0mAxA1hSw7swct/Xeg
+        SZdlt1qLAofrlQLiMG0Ly76p9LvO435l0u9nBL62Z8kfNE2Y8E+w1fU4ZmL2qVSo/atIQNzjb9XQ
+        3mjBZv68TjbyfPrJNXT57WZXRMh7mP6NDne+N9AdSnGjnQ6u2nWuy74sx/1iu9MKnmti0YTj/O3Z
+        p+jEtoaoWUkNHFMl0eup2V4+PzGA2fREPxBNiuY90q9jCVaCBmMZ5iDdjyGjVcVabFZC7H57GjKM
+        +Rd6iWnHc4gJSJfABmw2uQVtd8eck/FprwLmIPysWAY9PfG7DWY7mJQy6DEaeced3vySAUHTBfqi
+        Rg7mQ7K+MVfZodRj5MB0tMkD9Wky5TMHCHoyTGk20xeNm2ahYUpiVPbI0qgEml8xOmGtyEyVWa8n
+        Z46iW6lHkwvmA8rH5EkGNEpSUyPqY6jlzpxsDbcUM9q/hpmmEVQaruNlQIwYUCKAZCiwViVATVfQ
+        TTSecVl2FSjQVOpXneCVYqUpSwkrh5PDqIVqexK2w4sOpaE39j8pVQGsArBTxUhkooWB0ayGaM1q
+        S0/8bNgTdtEFZi3cvk/JDgwSjzXjhEct5hFd3YeaOnVOfJiBNHWYk1KPSRabfDV3y6XMhqBc/Phe
+        QRMPtenCD7u02ckH1ciA0+wWgbRZKeyGDJqTaL6reSRzR01EhAbTTs2RmZwgGfyRFUuiyhQXIkAn
+        kUfzJdGH+RCJyJtmijJ6qsYggFNASby2IvwGiGZZNlPlJZM/5FJ3hOPCryOyOcLp/AnxMISRXDKD
+        l000q5IQSXsJQdUFW6hQFxNPZetWGa9AUCJI9+nqideSbYmBQzFF0DwASoYOkEUuAzKkyDlW0beg
+        EG9aQDE51dNQbcZnQB+nI1Whv9UTuKcWM1w6pL1EZLW2Rw2WSU/SB+G6PmhoPgcrJNDYN4F76iDz
+        0MdehprsKaFimfQ0bIY9bFqbh9O5NI8P4S2iclFtSJUgaJq5Z32lo/lPV1N3lJPm5JJsWdLgJhlH
+        squZaKskjoq0l91e8qXJ4BOTx8JKuoulhFL/XGscrBmfauvxunL365gyGjMyo/GTQaz/yjaiPDWN
+        oRgt8YduEiWUgu54Qi5cf5eDROpBXhT8LqgO6wuoD7oMOXVnPl7ryGeDxjXxZYqCyAhM90n9JdW8
+        Y4omXkHr9hA5dWAAID3YsTud7SVgNCwgQ677oZTJgZSdpqVTOAiWf8GgIVBy3ciBoP6EU8juNAOe
+        SutsAJOnyQETCKCh0UUF9S84G9IG6X+SuNPFgMy9Z0oXEsgnRBpAumrVk6DhqZj0IlqWZIQEemnY
+        4D5Ufvkv5DUhjb5E5+fOu1NXcXoDkY5GNnBL7+q4OIXILHJzdb9wyJmLA1ByhUk1qVrr50rQDxFM
+        bNDLQK6XcCgGqW0pTO5SbGpbMba5d7SbN41EoNRXxIkGrKVVPKgQd3lo5Hmj42iskQNLuUUXedWk
+        NAwjYy6JRjASUTNSK9SuwvxZTl4IVXuh4lk7BBKVhYvsJeJorBSzGFyMO9a8E0YIqEsC3VyjPR0d
+        stkAZ+Jo71A3aupJV/wMKtwY+t1Ngo5axdWE8KkS+RWN4FyFd+CddOSEpAbZCww/qoEHtUNKCCSp
+        RHSywSJRORIExQj80lSL0U6CZZlSwltzLA1ukYbDUz5XcRh/qZAkWSrJ2m8NVXE1RixQdpxwtQ6O
+        MPsRZNKDPMkDRx6Jtn8RmC/Nz3qifJm8GmtURQ82lT6kc5PPY2ithWMu8IiR60IXpeHEC9on+Cdc
+        78Cb4lqSPVAlytqqvKAwGh/hYzSw+sFBzjw6P2MBdJZuGVYZfwUUH5gGcFEzg5A/qCFS4rezKRvp
+        JKeSIsmpJAnr0SSbq+OTyTf9CBGmThu9ud+bXXfnlhSleqfQkuiL9zBZGImkEnmNrPLQm9j+hC6v
+        qqz19GQHfe8+f48ub0T9mfr89V3+OeYAYubs7bqXmJVvJHSdXAM63cfEhhE+lZ7T7AGJastG/AkS
+        Ze2Ux35NpH5yx98tSdK90nA7O/57liTvZxk9PlpJ6klpM+zaWCbrxoZS6V/J16ZcITWSKxMeZl+p
+        DJ1mD+80QddEY92LVq/3ml3cdXKkmVGGQTuuYmoz9jFiyelUKnknXxkW4LMZa5Sj3k4LEAdXA39O
+        YQHWe/qvbAEy5WnhIGPu0mkEEaMciwTuKgdBHUWECx13MTq01tYoGJp9oVl2XZOXIOjis2q22tUa
+        g6IG9XoT91gt6JhWw1VGnmYDv1sbUM1Wlbw+71XaHkkNQqqiYJchodWhQN3HUMDNyDsmPCGztHYH
+        KllVrXqHvI2gJcDdEJSbzQYo62ook46HmDxNLHq8bxg/KtGRwd7GnZc1SDXicMP1VavTKByBViFu
+        OfIFEYtQYdtz1wwufmIa2GywHktbs6t7i13RMVsGhyBzgFZ2dW9rjbaUesdndlLFGUt1LVk/3RDC
+        Ze8aVIrj0S5WjAwFUKFi+LhmivYZOvAG9zg0Fm86oW8tMNa5xrx7ip8Sry2TqG7nJcSth82hSIxZ
+        gFe3Pca9DkqtoNur+W3K+OJ0qwnEFmN/KwBgGMlbSdO4CDljoi/fBeLDGkDXXdwramhSqNWG8gw+
+        cMOu2UumsVUkh15GxAHjAPPUBgjWOm0c9X4noqOxEdpdXSk+wm6J53WrLsDZjOPWXM7CRem4h2t1
+        BBV6ysXr0y3bZGZ8lfDwBPhOI6HmBonsHUWi/balSrqbAEBuxWHEB68CM0OBFfBOuy2UmsJICFMl
+        Q3OGELNaVcdw0pYEcFUbyMAqlD3VWvIBkynshlXhSC5HA7KxwiLhkzS0RDTWL/S6LYY0ya6uFeIh
+        43VXudtCK2iK1U2sNFgndncumPa3gs4TOO2/m2DfNkM5mPHZCzv4bp25XSc3pBZyqhcCwFe6OIzV
+        tWiaxJV1HVocwhl3dW+RWqbuNAN7RbQGvAkNsCjT6NAGPRq1rdXMrBqa+bTxyWRvAugZNjoGuBCo
+        FHAINl0TNl0L/qc4ITd+h3ZAaHFXvQmwYmTaJPgo2OraKDd0kUSr3aKJDartSnS45HA7YnHYHMNy
+        CN9QK5ibA6TFF4YwCvh+IE0jZ7+7qqyUow/HGSugEHoKAXLX7G0zVCcIzI1SbyE4lKij5LoBDx2c
+        kKmiQTZFGZYHUrCBLVKkimZLI0hFBnQPqRl3ceXEDF51fHxanlZ81DXhVkMy6d6gDOWMQRe3O9bC
+        hmjF4o0gtq9RegLSbNCxUDLq/tIxaI9UmaoVmKmmfvVGAoZGh/QBjwQwAGpXW1jsapjyso4YQ7i2
+        qI4jTeuylirFrc5DKuiHTLFEKBLrNqB0hTQJJn8UaPgtyS8NcFeBt80hErXORO44X72G/mJKEn1P
+        tU1TwOqFAYJKk1AFrNcom9jpq9fBdTL66pb1RitiPRqF766uEppqo0GopjWsgbqmL1mloGSn/VJO
+        JiY6UKjeYqqDbmkyz+LHS/jAG3ULn/lnUG8yLfKbTVSy8shL0Gy+lOuQMcOrtRlynViErCHbGIp2
+        QVnwR2/BJYlmEu30EJHXRxhtDcowYmCnVT59lvUnUVdKDbojQRqsaXujMYZxojx6FdI26ySqR9B8
+        dfQGhNH43UWG9NmtRILVxRb9wu/QLbi4tvOGsTZ4SlE0r0yLdiPtAtKCAGRi6qMJ1Qc02ElCkE+7
+        CITyMLaBGFWQ3GSQcFf3VhKrnp/2gab6gNPKjK1OKdhAqz4AXq4PSDtLzHmjnkrrERCqgGWCp+4B
+        PGECHd3ValN6iktDPcAGwPUeYG0ASt3Yb+2DcoiqNVDameqgnHWdlvjAcqKgGhFt1Mf2UAu15Kf/
+        rE+KCp1WD2wRT3VZp2s77sFaAqnUz6lNWpiObu0XYX0D2zKwXEuEM7B8fQRXzJ7g6t4WKGk4LBsU
+        gKUNAuuso3ACivTnOp0KVNfHFnW/jsY5dLL1TekozDDXMHXcVnls0RpsmOJgFtHdxxYQYzSnPnnP
+        O51QQwtGqLsaOSFolxHWBi2wgTV2ce8KjDrFyCK7tSHNkY0srkHiTFdNoUpGNZkcbpDvyj5gxdtd
+        C8CCUzfDQVKEycLVvVX6lsnCgI28WsexJ2sPBeQsyOwWJCm3ZlQrfcxdDS7EwHwGLzSs0jG+3NW9
+        VWNVAdGeNq0W1V2yWiZ0EoZtGeKmpIKXbITBjS9iB6UJi62spGuB9Xrji27XTXXQVy0GBbScL3lq
+        SLiRVlP2kvwAsW3WO5F0Fu3j4jBUor3GL6lijJdt0OjKC5W+wT2lYYYLapHRuSkABs9PVIP0nKXw
+        hv7DQoDmEJRGzehm7yT2gDetiHj4ELiJFStAgZDCfe6uDi2lq+y7Ccg1GvRgyBOwMqFOcVHVriPR
+        Rj/0fA2BTrTaqokgNmLL+t8GdQydn5E6kKlEHdorMm/SCPKgFI1EaEWRSMo3aJZJlFHIEe89UMhN
+        j5kb03VZI2sx7EFPJzYMeDAKZY3OxMTCLNYQ2hmjsmT+trATmGBq/Avr0ucttljwzm+oHzB6uGfY
+        6faoMALZOK9NK/aMTEtJImWaB2E4UwC7G+MB8xZpY3ykQvQWQ5ItJfOzg6GoxT0GYUY+SnQZASmH
+        zcjQLYOQXVHuUdWLlsBANroM3sz7mc1SLY5bOmNTY5QfsFJgMzENJaoqMBvEDP4O+leVy2pq0YNV
+        Ycemuc5g1bPASbuQw3jOHFtppmVCTAEa4jSDSTmDPGSlZpEofUTCkWxpN6l/jGJqYqMMIwxUR4Xb
+        c+HlwFextmFb+5rTDRdr6exTuNjIapGs+Z7Mvm9gQ1N0sXPrNBvFixxVNk/pwxaFSGX/iH3hThy+
+        KnHYzkflMFfZ/mrDR5vNSzC0DcKjumqPEBI76szK2ib1tJxtndhuapbVqiFa33VRzW6oJQNhW93T
+        Dd5hvbzB237dXHcORB+r2H75/TbD2574Bw7tT7IdIriwAHN7hTt4muGR3Y8Oo+vhICeji92vb3q1
+        GmfMTGY9iytqX75lDDXO2sdwNxCdfU27gLx6pZhwfF1XwH31Sp+4KKLiDeDU3KNd7M/KWkBQQ2px
+        6G61+XD+u9XDLL7TdnQdomoQVpBAwK/OxtH0ttoNA30skcorvLT4dmlbvAwRhh6iWtirhwdFYv5h
+        QfmzggM+thtFVfftg7Y8rXBhDoigopgZ7CEc8D0WKWxr5AdR8tLPMNbD+m19qrFj5xpIj+Ybu9nW
+        V7I1t2qUnZZ/r9vRPdvFt6kqs+6U3W/pVuPR7l5lQnIHyU8/SLmr4KfFTOb1gcx0ebi8ZPfq7/R9
+        0cPfsBHug4l91oKy1Odpf3NC/8uXPX/vX/Z8VN3ffehyW+9P5vrw331Ux/fgyWzxIP0ubtencJkG
+        y+5m9VwzZtlAWZ0RH7U0ZhWJf3Pd95cvfn754gcnVPkDH3Zhrif88sXPx/rFj33XIE8XnzHsq6al
+        G28wxfhUYfdbJmCc+pTpyOy+Y1LkPraOF+uZj/gEfUe9R2msymyOoFzFJPoaPb8xS78ml1A8SmMS
+        Zdp8XrXQ3F5v7oLT3lDUis9HPUXgy7BbVQcrvnExLX9LUSvOBMRLFr2HB2sBwV2EKn1MsrgiANXc
+        wiMTpYd51U+NwL8LUW9Vdd89VIl5WA5BLhQ3/7FTxDV5nXtb2aBrL7JDSbIq05/7kMWG54wlDsqr
+        V0S/J8jEwfHT6K33LJ4TFvGQ+JTM52+UVyF2dFhgcz3algte3pBjyKfACmzBbJFgrttH6yDZ/k3F
+        2fHrivdj5sb3DPC6EamDOoMb6iy5kZDpsyt9aHQLC+RCuh5ixumjedaYHO6rV1loZ4izpQmyguV7
+        HmzX+yLu1byAz5GIuKtQkH7wgK9z5rUJ4exeIHS3w9uJ0GqOGSZefeseiMhBuC7P76imIFBNXVUU
+        uYpuRfpWTHbou3KDb3i9Wy1mhY8IjKIQgdfTgfbrKzYUvVmeRPFS0Nhqmpb1pjnnfxA5//jDBf29
+        kWQp0sEOpEnbRPqvEz745gYMAyM7H5ZtkV0fxLn+ThdRgBE5jrOnKkcm6Kya453BiW/p1Y7VfH67
+        VSdpRZ2O1Qrp8rcd5/hmDjhi8J3wFjFI2yKGBQX+MBGTd3pXcXKakykLpczBGus+U+IX2afSBP6d
+        IjDTWRp+i/B1fAazWPAJ7LHGgAyAojlN5Fyr3UymVFD5CHWLTqQVdLpWUHdEe95LTNs7aiStqNGJ
+        6S+BozEjXQw3VjLuETh6p7hhQxLVNQvndngvaStFpJacKYbUVl2K6JzUCJE8sShH96pnM9S1KvuY
+        wl3f3L+cGuKj563upQ+i83Eg1ckErtuioSLfEkm7ppgKySFfa1sk7Pvx7Jao3MbHnzUy983ESZWP
+        9lhoKadsnJBWUOda5XOUr31trhJZiGUt7o6OXeTjvZSSrw0Nm6goscAlU0t2XkEayZkYbSy2fUSR
+        xm8me2oS7rQJSdxs62N6tkVoJtZcevqDokW6aIQuViqx4lxM6yKe5S9Ry2+NWr4Xl3YZwf4OK3if
+        COhbukVrtQrylx7FR8jF++mVpzkMqZDKthIjCL/FW68RqPTQzoPVqvH9Kstit5u2UoTRrWYNiA5u
+        p5+aTXWvUSePCe8a9J7iwm9hvh5r/X70KcKrO9yxHm4NOL+XKO6azXBgzU6FsTsu8n2D1++F3q6J
+        j79j5kPclgUxR4/XA+LjMnLJhTipZxD9Usoui5R/L1kqAxBL9mrNrpmLv2PqkrWm4HoW4/TB9U3S
+        dMOwWpe3e7XuGlh7N3TX1MNfm3u4ITdvqI5icucP7Ghgtgslmo+wmIqDC4aH8zfJ4ZjNL6v572bz
+        h+xH+U1CPKDe8OE1DbgXMe58IMLeZNo1X/J3TJhuUymK/Lua36dxWT/nmIAlW4vcjTOMxxzacnC8
+        frCDmlV0pIwpZYYw1FhUX2KS6oxjTRR+PqQ4ckguTdAqwpTvRuka67rAtMrjvfTwbnIVmOXnXdwu
+        Aop7e5Qay/6uuYQSC7PtTuYy4sApps5Qfm4/9rOUdxnt/prVnnbbzc1kEsBorPngffh9nOGIfGF2
+        bx598MvBIKWw1IoqbeGey0dh/J0cDLLPGBrsms0psegqTkY1w9ltsDCtcweDfbhDRrYUOGH+icjN
+        AXXn4/j+Bu0fSmeXSOPsMNI1G0h0qInVEk8P7UfVHa93Lx14bGekmObd6R6yg1NU271UwQsr7hoD
+        eETdXGU3nb2yl9jsmhgHOybGmUWSnueywxpJzqdjAn2nKm8SH34yP/xnnzNfCDaqA1/u1eytY2Nu
+        H0DcjD/YNZdU4mZ/2BLBQmczebPjHO6DeVbP9QZESblv4+AOyKqVcBn2DuNpdZXIktAyWHIYtgjf
+        x9foDX2D/FxHNMi+ePzoX38+fIsR/J62xXjW0yGD1f7sclp1rblX59pNzgK9OxgYqW0R7JrhKbEQ
+        kDvZFrb5nBOnomVi0fHNG5edILOXmRHsmtQpscDoGjMjq/Xe2qXAc7epYdYrpxm4wfWvfsrSVn/h
+        XI34Kj9pmRX0xmE9OPS7h8u4N5wSsPT86tB9HnCY7Z6vZkS7lzweI8/FQU9OLXMaoQ4T1Dl4vP0b
+        Puxpr4Fj15w92DFnfw/2Riat9zk4akt0frE4rllhfV8Wxy4fiAIDb2m51Ed1vcWRTbUv2bsSH/71
+        TI1d7opgH3eFjNBMDZkdqmFSwYZ/vhG87LLI+o3ZqFsdYQuZzGXx8yFTjNf3NCdWc87L03FIufau
+        ZljeS41nQrdupRVobpkVa8fwZDuTsnvmtiB45/bKmhILEb+TaZGfvpW5LvLT3/azK3a5L4Id7guz
+        IeMvFkT6NndDcRrXL6fYyeL+KE6x22dwDnc5A5RYCKCzJF/oDFJWleQfzw8XK8QAr/oN2w6POABp
+        E+CN2wf5fPPYHbG3pXzWN2ncR+Mcv5iVj+0zHacFs596dN/Rtdu9825Ps+5+vt9+cO95CGA2W9cI
+        +ZMPAyzm+vJrpKNyClnrCaaB4/XTAfMy+zXz/mcJ3gz/6HC2Y0d+zjjnKgh3uQqUuCncdh6fPC9/
+        w8cW3tyj07mxTuvY2hqixIIidxnAcALYkc/p8PVslp+buNf4Fe6aFyuxwCbVZu/hEMab6ZUK0K65
+        ULhjLvTLgY4f5EDHvXi2axoS7piGrB0OeTPkM3m7flzNOK1Ve87DXfMCJRZym39qUxSlk6TnuR6/
+        YFQ+Olsc7zqNUum7T6TUm+1TKZV63cmUjJX9vnbcsTJWILL+Y+fAjpa/bk8+MDlhmpNU1rfrb4E5
+        GsygF4ffQrA5u4iq7ndOpFKal/Sqg3ezq/7KO//hm9XXl5xiXRRYrydX8aWvPyj+6O3k9E/eIPn2
+        q1H5XMssd3YvhxCxUsP4K+/16dXF+OUtn3VslZwsOaT4+y+Gz17fUlJ17yxtrZ6/+fEHb/R89W3C
+        lwtbRMzwLt8NVsLZuBxAU1h+jgbgZFBnVy8SDqT8/lFvsCdUwzJb5WTKZaEmxtGZNmzzLVI6bEQs
+        el4pti3RJoy9sDM9Nah+ov8O2GTXB7Px6Hy4zHntcPrzuxS7+evvT7zzb6fPB/uE0Vhr+0ZIjbOo
+        j6AoSEh+2I1okp11o+e1czuDBpF0lJpGxzoh+hPxn/aiexmP0hGoyXVnoG4H69iPv+V6iuN9OOKJ
+        Q37yVrqjnbJ2ul9pmwYDeH50qIOB7lFhfioLkYkUGPUCcg35e6kfPzxVnH2C4utUkO7LrgLW6ggA
+        C+5N1GZCihKFifjeROOzAxeIWkTQ9JCA9jrnT+mcOVp63gZRgsCBLURgug0CwbHa3SHRbEPi6Dba
+        EaHGiAiti84OUfy6pv12wdWIQK9AUor8p1hSeq3oqIo5SaBFi67fINATMa94zwEC4amvMxbblS6R
+        8O3cVZVTyKuGzmUNmzpwRoceWHziINQJExwgoP943dTJE36Y4aXjAzhycRdeEEmIWejLNcQIyUYY
+        NcKXEWaK+sCNGjhtgcBXHAzJVfE/lUhwKIKp2SPB/IhppSMZLHocsdpAt5GjqyhaDl1i+xPCrkCX
+        wyVB94IjKetNCKmjDIhwzn8WK9ZOP/CfcBwAoVd1ihFHJdnVcug0Dd50hn6DQ3HAVBnDZgS3A4TA
+        rgAycMQ2a7ae6JSIziMYrCOXuAiMOysik7AfJj7HtXH8oAIk61ggSVqV42I6sFSSZsfmcDgMWBOC
+        T7G54IjJl94EBOiS3LnnCw6E0pkgOYwSCB0CJRCQ70YICvMpEIQG40AcopzpINiA0JugqAcjTjMi
+        DCfS7q4Zceg5RpyXhLn0CSZKOEjCcbY57smuGWksuvMTi7sdcdRtShRC9umYpU5THabjS8glS/ZW
+        J7A2xSCC+oEXos0r2hrqhCu6gSR8LAGBnYqx2CMIMweyKNap0YJDpzgAAhZJsMgiwByFS7h1pEaH
+        HNF9FZlTSf4jMuk4WC6OXT69i25neAWbnY+6GxxlBDHATEF7DTUgClhdqkGoKZ6qTuuCqep41E3H
+        08FXbTVSB/zWhU9XncvXUV3EGEdSMwRgCX0kEGbl7sdJmQ6zQkE0fsD/sOvMOCLOKwwdGo6T4jAF
+        FTD+TmMC9tJtMYLW1DpbF/aCf8M3levw9vuudctmyu2F75986Q2/ujw/Od/TXjArxKaSHIbO19tp
+        jC7nlKmeRYvy4I91ltc0efqldz4+mX+HxXVkX0MPiBtXvUxPz+bw7f7dxuMSEmntNmnEPwRYZydp
+        q7k7Wb5KjT3czHxMWivmcc4+OU2+8Hrfn/T+CGbOb7EXjzJGYCXp+L9bP9nO8utuVHQWUz9avFmn
+        2etHE2fN/fj00XfemyfzdzNszT1FIqvlqBSeTWaygA5HX3/79qs9GZ0DKgWqygCdvRiORk/vCMja
+        nVma+UoPCybZAq4tmOB/upsYZHiuf3LIN4b5p4XrXx+mFq1sx3LktbLd+ziLNHcnOcgQmUYTDOEc
+        RmoYp2xeN5rvBT+dbO6yrS3tx0dnp97oXydX//Iv6mlFLLqMzut2s86zz+xJPa/ZzS7eW2o17xdX
+        7ucwfzNSFkdV/r3GmbvXqJOT526jT1Fsz1GoKHBdgJQsx+a9HNfx51caaeS496Uv7tUr175wXtMx
+        eZy7sophLX6Jl+SAKJnSFvnP0phwLzQ2Z+V3Vhb3qlXsT2tKW3tvHXPv+j/U1DwT9UI3/RIO8O89
+        HOAvWjqT+uvvWyvAtteW3R2TXE9vhIUo22j36vbX69y87nWH5lfa/iuUMr1bJNwLgZK23vKHfnDN
+        m7f5/yfd28ABY8c1EsAPT5SdocnxkbrjZUqIv647f+43dzw99ps8rec4HVS8koLxTtMHnXQpiEHY
+        kzMSyBxhIZeI3TnAIOEkpQp3/ji7lN/c5WjTbx2l+TzEvWIOUQE5TYFlYDkUmZNF5UIEMn4qTo7R
+        DUdfkODAsQe8Ky4BjxLv+cn/teA5ZwNwXiIA5FXFScKTA68nKsCtwlnLOvAahwngdW4px2PjyvEv
+        dKKyTqHUG3xESsPVxHUoZxQnD8vrJzchJ+uBnf8SYDq2lxf8+Uqq2osTDhrlDFb5aNPq8gdQ4CUe
+        GU5JfKK33glnbdhPjm3VURTcOHLeAT/R0KE/HauK30bQeDB8TjgWWwcgc3xv3XK5gbZrzTjhhwGz
+        TKqskld7mj8VZz/cq3/f0b2TKUdtVblTfTfvecjAZvfdUQmzt+X7nj6DPbLdkuWG1ze92vJLfeC1
+        vNzTMov++NTrffnsu9EeTo2joUJKaLVr03fDYua/PH3mzT8/nd/mT7uBLBkHtxYPhW7/z89OTr7f
+        B0sC8a+haf4yFyReMfr5xPRNUnY8gfz4y9dsFBwMFE1tLwGWl6lMiiXfXz08wLXSJ9oGX7BmswLn
+        mPj8zbl3/uX3vcHbPcGLEppK3liFtStdtiY6fryYJN5s4BFwaKP6Zz/84J2/PhueDvGLRHu1L2PF
+        jQi4KZxVXJ0N+KKHit1RDnytADbXrqHeCQULrfbw4GJEFBN29sXei6yl33LWRNr+9RZPv/vTj+m6
+        8Ns//hnSf3uVfHFwnBW8U/VUcie1dkeVdjcmzxeji6h35c05cbV3td7oH98vm9Oqq1nVKaPT5Lu5
+        Lk1ydyytb7H6WdpenTBLszNm34mBZXv0GsFYr+bjYXfU67GXZXQ24nzdK+830WT+mdfr3cj2m1WG
+        67FrYKsCmDJz7cV7YumjHW06OXlvrN1d3UfE4n5vqC+FN0ak99yZo6JWx/psWYJwZcQlJB5UnFQn
+        54saZ64kS/dl8e/m7GwiQDKBDG2zV93/TbSVYuOgy/RqPpv/Zo8y72mUeNQ/cYTNRWttTL5GE+Sl
+        PiIJIRDfklF9725/J+24ZbikKkKVMqIXqkEJ74tVaQvvxikr9G3y8TCKFTzOoWD57UZO3Yk7e5hf
+        1FpNa021+KH9zL4hfU9qXIu/z9XYnGl3atgeg3Jew8fD4Wl8mbhl9Zt7451IsQeP1+pNuVxOu1N9
+        extfbL3NWvvemFyq4+Nhs22Z6S1G8+WHZfNavSmby2nvh80vtEHItfa9sblUx8fDZqYUmqyzb2aG
+        c/zDau20btsjbnWn7GYZc+w2or8nvX2aNvqxa/R74/hGPR8P1zVKS3cSdrv3YXmukbpUs+N48fVZ
+        /krLRu+J+xpTpXKt8e+N92u1fDycx39ERM35B7XO8jrT/p3+rg2Xk/F74vFz18z3xt0U/nvi634+
+        /qNDPLk3e2r39TOXzS8zjeh9c4KwTNnj2ZvNrxabH3a4LYXm2J2+/eP3Xvzi6y+W+3zX4TZ/OvNr
+        EUcl8FV6zLpYzrQ30+qY/fm7P3qvr7751zc/Hhz/3//jjjo50QGo1pO5LC9nizccGGA7MRW+cbeF
+        9+oyyufunLo0Yd8mHsRCC+XfdRTZzhez1dxWsbPPXJzjP/XTfWc5n3KUT1QD/fUtfmuz7dn6pzDW
+        sPnk6RdeTICzJU73R3yOC0LZOX62lXUQTUbjqwfePz568cJ7xLD4xnuOqfKPFe9JTOxjvsqJKt4j
+        TogdV7yEFwRQWIwGHPp3dLYGx+20feARZMr7hxHMXSyj6ZJ8Dn++FDu2NmQUPHG0gaIEfTWsyrOV
+        azjzaDz2vpGoJN43MYhcxP2MJbfCcLL09NE33uDdOLp8fHBscx+a5P3lv/536vcz1vst73rW32ge
+        3tIdbnh9zSuOWLIPotZ74dGhDvVaT8vWEo6clek5l4P2LB++ji4il3rgzs56naRxpl8nv4u7/f6g
+        1QqD+tmgEcWDsBv52g7sChR1lBCEl7P+1fGv+BoXBXv8q/8HlHbO28nWAAA=
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '489'
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14921'
+      Content-Security-Policy:
+      - 'default-src ''none''; script-src ''self'' ''unsafe-inline'' ''unsafe-eval'';
+        style-src ''self'' ''unsafe-inline''; img-src https://cdn.cnn.com ''self''
+        data: blob:; font-src https://edition.i.cdn.cnn.com https://www.i.cdn.cnn.com
+        https://ix.cnn.io ''self'';'
+      Date:
+      - Wed, 29 May 2024 14:37:06 GMT
+      Referrer-Policy:
+      - no-referrer
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - master-only
+      X-Served-By:
+      - cache-iad-kcgs7200172-IAD, cache-iad-kiad7000167-IAD
+      X-Timer:
+      - S1716993426.480080,VS0,VE2
+      X-XSS-Protection:
+      - 1; mode=block
+      alt-svc:
+      - h3=":443";ma=86400,h3-29=":443";ma=86400,h3-27=":443";ma=86400
+      content-encoding:
+      - gzip
+      content-type:
+      - text/html
+      via:
+      - 1.1 varnish, 1.1 varnish
+      x-amz-version-id:
+      - hJxM55Lcs3LHhZMWtFC18Vdsd5C_saDV
+      x-servedbyhost:
+      - ::ffff:127.0.0.1
+      x-ua-profile:
+      - desktop
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/scanner/tests/test_asset_scraper.py
+++ b/scanner/tests/test_asset_scraper.py
@@ -252,6 +252,22 @@ class AssetExtractionTestCase(TestCase):
             extract_assets(soup, self.test_url),
         )
 
+    def test_should_handle_unfetchable_urls(self):
+        html = """<html><head>
+        <link rel="stylesheet" href="file:///Users/dcao/Downloads/securedrop.css">
+        </head><body></body></html>"""
+        soup = BeautifulSoup(html, "lxml")
+        self.assertEqual(
+            [
+                Asset(
+                    resource='file:///Users/dcao/Downloads/securedrop.css',
+                    kind='style-href',
+                    initiator=self.test_url,
+                )
+            ],
+            extract_assets(soup, self.test_url),
+        )
+
     @mock.patch('scanner.assets.requests')
     def test_should_extract_urls_in_linked_css(self, requests_mock):
         requests_mock.get.return_value = mock.Mock(


### PR DESCRIPTION
## Description

Fixes #1125

Changes proposed in this pull request:

This PR adds some error handling to the scan process in two ways:

1. During the asset extraction phase, if we cannot fetch an asset's contents, skip over that asset and continue. 
2. During a bulk scan, if any error is caught during the scan of a single landing page, skip that landing page and continue.

See commit messages for additional technical details.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
I've added unit tests for both changes, but it might be useful to try this locally with a bulk scan on the problematic landing page that inspired this issue.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to scanner

- [x] Verify that the directory scan result page in admin interface loads as expected
- [x] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

