### PR TITLE
Update Landing Page Directory Scan User-Agent to Spoof Firefox on Windows

### DIFF
--- a/scanner/utils.py
+++ b/scanner/utils.py
@@ -9,8 +9,14 @@ WEB_URL_REGEX = re.compile(r"""\b((?:https?:\/\/)?(?:[\da-z\.-]+)\.(?:[a-z\.]{2,
 # landing page or its assets.  Note that failure to include a
 # User-Agent header can sometimes result in false negatives or other
 # unexpected scan results.
+#
+# Setting a custom user agent to identify the SecureDrop scanner
+# sometimes breaks the validation, due to bot preventation tactics
+# by some websites. To work around this, the User-Agent should be
+# set to a recent version of a well-supported browser on a popular
+# platform.
 HEADERS = {
-    'User-Agent': 'SecureDrop Landing Page Scanner 0.1.0',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0',
 }
 
 


### PR DESCRIPTION
Due to some news organizations opting for user agent-level bot preventation tactics, some landing pages were returning a 403 instead of a 200 status code, which triggered a warning in the directory.

To work around this, we can spoof the user agent string for well-supported browsers on popular platforms.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- [ ] CI passes
- [ ] Verify that the scanner remains functional with the new user agent

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected
