### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Something is broken or behaving incorrectly on the website.
+labels: ["triage", "bug"]
+projects: ["freedomofpress/24"]
+assignees:
+  - harrislapiroff  # Assign it to Harris off the bat for triage
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report with the web team! If possible, please upload screenshots or recordings of the bug to the description field.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the bug and when and where does it arise?
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: If not clear from the description.
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      description: If you’re not sure, check <https://www.whatismybrowser.com/>. If you tested in multiple browsers and OSes, please list them.
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How high priority is this feature request? We will keep you updated on final prioritization.
+      options:
+        - Critical (ASAP)
+        - High (within the upcoming two-week sprint)
+        - Medium (don't forget about this)
+        - Low (get to it whenever you have a free moment)
+      default: 2
+
+  - type: textarea
+    id: people
+    attributes:
+      label: Notifications
+      description: Is there anyone besides you we should notify of progress on this feature?

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: A feature request adds something new to the site. It may be an important addition, but it's not a fix to something broken.
+labels: ["triage", "feature"]
+projects: ["freedomofpress/24"]
+assignees:
+  - harrislapiroff  # Assign it to Harris off the bat for triage
+body:
+  - type: markdown
+    attributes:
+      value: What feature would you like to see added to the site? If possible, focus first on the problem you’re trying to solve or goal you’re trying to achieve and second on any solution suggestions.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature would you like to see added to the site?
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How high priority is this feature request? We will keep you updated on final prioritization.
+      options:
+        - Critical (ASAP)
+        - High (within the upcoming two-week sprint)
+        - Medium (don't forget about this)
+        - Low (get to it whenever you have a free moment)
+      default: 2
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How important is this feature request?
+      options:
+        - Must Have
+        - Important
+        - Nice-to-Have
+      default: 1
+
+  - type: textarea
+    id: timing
+    attributes:
+      label: Timing
+      description: Is there a specific deadline for this feature and, if so, what is driving it?
+
+  - type: textarea
+    id: people
+    attributes:
+      label: Notifications
+      description: Is there anyone besides you we should notify of progress on this feature?


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

* Add issue forms to improve the process of stakeholder input

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

I don't think there is a good way to test issue forms besides merging. You could copy them into a different repo and see how they work.

## Checklist

No need to QA; this is not a code change.