### PR TITLE
Allow `WAGTAILIMAGES_MAX_UPLOAD_SIZE` to be configured by env var

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -213,6 +213,8 @@ WAGTAIL_SITE_NAME = "securedrop"
 
 WAGTAILIMAGES_IMAGE_MODEL = 'common.CustomImage'
 WAGTAILIMAGES_EXTENSIONS = ["avif", "gif", "jpg", "jpeg", "png", "webp", "svg"]
+# The size needs to be set to an integer in units of bytes, e.g. 1 MB should be set to 1 * 1024 * 1024
+WAGTAILIMAGES_MAX_UPLOAD_SIZE = int(os.environ.get('WAGTAILIMAGES_MAX_UPLOAD_SIZE', 10 * 1024 * 1024))
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 WAGTAILADMIN_COMMENTS_ENABLED = False


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

Allows `WAGTAILIMAGES_MAX_UPLOAD_SIZE` to be configured by environment variable.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Configure an environment variable for `WAGTAILIMAGES_MAX_UPLOAD_SIZE` and try uploading an image. Uploading should still work, and the max size should be set by the value you chose.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
