### PR TITLE
Adds settings to configure WAGTAILIMAGES_MAX_IMAGE_PIXELS

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -216,6 +216,9 @@ WAGTAILIMAGES_EXTENSIONS = ["avif", "gif", "jpg", "jpeg", "png", "webp", "svg"]
 # The size needs to be set to an integer in units of bytes, e.g. 1 MB should be set to 1 * 1024 * 1024
 WAGTAILIMAGES_MAX_UPLOAD_SIZE = int(os.environ.get('WAGTAILIMAGES_MAX_UPLOAD_SIZE', 10 * 1024 * 1024))
 
+# The size needs to be set in pixels, e.g. 128 megapixels should be set to 128000000
+WAGTAILIMAGES_MAX_IMAGE_PIXELS = int(os.environ.get('WAGTAILIMAGES_MAX_IMAGE_PIXELS', 128000000))
+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 WAGTAILADMIN_COMMENTS_ENABLED = False
 


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Refs https://github.com/freedomofpress/infrastructure/issues/5580.

Changes proposed in this pull request:
Adds settings to configure [WAGTAILIMAGES_MAX_IMAGE_PIXELS](https://docs.wagtail.org/en/stable/reference/settings.html#wagtailimages-max-image-pixels). i have not reproduced if it fixes the issue locally

I do think it should have raised some validation error from here though: https://github.com/wagtail/wagtail/blob/main/wagtail/images/fields.py#L135-L140

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
I think this needs to be tested in staging once Infra has updated the size.

### Post-deployment actions

Needs infra to set the value.
