### PR TITLE
Add workflow for building+publishing OCI images to Github Packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Start
       run: |
-        docker compose --file="$COMPOSE_FILE_DEV" up --wait --detach --pull=missing --no-build
+        docker compose --file="$COMPOSE_FILE_DEV" up --wait --pull=missing --no-build
 
         # Check for failed services and error if any are found
         sleep 5
@@ -181,7 +181,7 @@ jobs:
 
     - name: Start
       run: |
-        docker compose --file="$COMPOSE_FILE_PROD" up --wait --detach --pull=missing --no-build
+        docker compose --file="$COMPOSE_FILE_PROD" up --wait --pull=missing --no-build
 
         # Check for failed services and error if any are found
         sleep 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,98 +28,39 @@ jobs:
 
   build-dev:
     name: Build:Dev
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Docker
-      uses: docker/setup-docker-action@v4
-      with:
-        version: ${{ env.VERSION_DOCKER }}
+    uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
+    with:
+      context: '.'
+      containerfile: devops/docker/DevDjangoDockerfile
+      build-args: USERID=1001
+      requires-deep-history: true
+      registry: localhost/securedroporg-django
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: true
-
-    - name: Create env config
-      run: make dev-init
-
-    - name: Build
-      run: docker compose --file=${{ env.COMPOSE_FILE_DEV }} build
-
-    - name: Export built images
-      run: |
-        mkdir ${{ runner.temp }}/export
-        docker image save --output ${{ runner.temp }}/export/securedroporg-django.tar securedroporg-django
-        docker image save --output ${{ runner.temp }}/export/securedroporg-node.tar securedroporg-node
-
-    - name: Upload built images
-      uses: actions/upload-artifact@v4
-      with:
-        name: build-dev-${{ github.run_id }}-images
-        path: ${{ runner.temp }}/export
-        if-no-files-found: error
-        overwrite: true
-        retention-days: 1
-
-    outputs:
-      images: build-dev-${{ github.run_id }}-images
+  build-node:
+    name: Build:Node
+    uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
+    with:
+      context: '.'
+      containerfile: devops/docker/NodeDockerfile
+      build-args: USERID=1001
+      registry: localhost/securedroporg-node
 
   build-prod:
     name: Build:Prod
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Docker
-      uses: docker/setup-docker-action@v4
-      with:
-        version: ${{ env.VERSION_DOCKER }}
-
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: true
-        # The build inspects the local git environment for setting build time
-        # parameters and will fail if they aren't available
-        fetch-tags: true
-        fetch-depth: 0
-
-    - name: Build
-      run: docker compose --file=${{ env.COMPOSE_FILE_PROD }} build
-
-    - name: Start
-      run: |
-        docker compose --file=${{ env.COMPOSE_FILE_PROD }} up --detach
-        sleep 5s
-
-    - name: Verify django
-      run: |
-        docker run --pull=missing --rm --network=securedroporg_app docker.io/curlimages/curl:${{ env.VERSION_CURL }} \
-        --ipv4 --retry 24 --retry-delay 5 --retry-all-errors http://django:8000/health/ok/
-
-    - name: Verify database
-      run: |
-        docker compose --file=${{ env.COMPOSE_FILE_PROD }} exec django \
-        /bin/bash -c "./manage.py createdevdata"
-
-    - name: Export logs
-      run: |
-        mkdir --parents ${{ runner.temp }}/logs
-        docker compose --file=${{ env.COMPOSE_FILE_PROD }} logs django >${{ runner.temp }}/logs/django.log
-        docker compose --file=${{ env.COMPOSE_FILE_PROD }} logs postgresql >${{ runner.temp }}/logs/postgresql.log
-
-    - name: Save logs
-      uses: actions/upload-artifact@v4
-      with:
-        name: build-prod-${{ github.run_id }}-logs
-        path: ${{ runner.temp }}/logs
-        if-no-files-found: error
-        overwrite: true
-        retention-days: 5
+    uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
+    with:
+      context: '.'
+      containerfile: devops/docker/ProdDjangoDockerfile
+      build-args: USERID=12345
+      registry: localhost/securedroporg
+      requires-deep-history: true
 
   test:
     name: Test:${{ matrix.target }}
     runs-on: ubuntu-latest
     needs:
     - build-dev
+    - build-node
     strategy:
       matrix:
         target:
@@ -138,24 +79,45 @@ jobs:
       with:
         persist-credentials: true
 
-    - name: Download dev images
+    - name: Download dev image
       uses: actions/download-artifact@v4
       with:
-        name: ${{ needs.build-dev.outputs.images }}
+        name: ${{ needs.build-dev.outputs.artifact-name }}
+        path: ${{ runner.temp }}/images
+
+    - name: Download node image
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-node.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
 
     - name: Restore dev images
+      env:
+        LOAD_DEV_FILE: ${{ runner.temp }}/images/${{ needs.build-dev.outputs.artifact-image }}
+        IMAGE_DEV_URL: ${{ needs.build-dev.outputs.image-url }}
+        LOAD_NODE_FILE: ${{ runner.temp }}/images/${{ needs.build-node.outputs.artifact-image }}
+        IMAGE_NODE_URL: ${{ needs.build-node.outputs.image-url }}
       run: |
-        docker image load --input ${{ runner.temp }}/images/securedroporg-django.tar
-        docker image load --input ${{ runner.temp }}/images/securedroporg-node.tar
+        docker image load --input "$LOAD_DEV_FILE"
+        docker image load --input "$LOAD_NODE_FILE"
+
+        docker image tag "$IMAGE_DEV_URL" localhost/securedroporg-django
+        docker image tag "$IMAGE_NODE_URL" localhost/securedroporg-node
 
     - name: Create env config
       run: make dev-init
 
     - name: Start
       run: |
-        docker compose --file=${{ env.COMPOSE_FILE_DEV }} up --detach --pull=missing --no-build
-        sleep 5s
+        docker compose --file="$COMPOSE_FILE_DEV" up --wait --detach --pull=missing --no-build
+
+        # Check for failed services and error if any are found
+        sleep 5
+        if [[ $(docker compose --file="$COMPOSE_FILE_DEV" ps --status='[restarting, dead, exited]' --format=json) ]]; then 
+          echo "ERROR: One or more services failed to start"
+          docker compose ps
+          exit 1
+        fi
 
     - name: Make target ${{ matrix.target }}
       run: make ${{ matrix.target }}
@@ -163,9 +125,9 @@ jobs:
     - name: Export logs
       run: |
         mkdir --parents ${{ runner.temp }}/logs
-        docker compose --file=${{ env.COMPOSE_FILE_DEV }} logs django >${{ runner.temp }}/logs/django.log
-        docker compose --file=${{ env.COMPOSE_FILE_DEV }} logs node >${{ runner.temp }}/logs/node.log
-        docker compose --file=${{ env.COMPOSE_FILE_DEV }} logs postgresql >${{ runner.temp }}/logs/postgresql.log
+        docker compose --file="$COMPOSE_FILE_DEV" logs django >${{ runner.temp }}/logs/django.log
+        docker compose --file="$COMPOSE_FILE_DEV" logs node >${{ runner.temp }}/logs/node.log
+        docker compose --file="$COMPOSE_FILE_DEV" logs postgresql >${{ runner.temp }}/logs/postgresql.log
     
     - name: Save logs
       uses: actions/upload-artifact@v4
@@ -186,20 +148,108 @@ jobs:
         overwrite: true
         retention-days: 5
 
+  test-prod:
+    name: Test:Prod
+    runs-on: ubuntu-latest
+    needs:
+    - build-prod
+    steps:
+    - name: Install Docker
+      uses: docker/setup-docker-action@v4
+      with:
+        version: ${{ env.VERSION_DOCKER }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: true
+
+    - name: Download prod image
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-prod.outputs.artifact-name }}
+        path: ${{ runner.temp }}/images
+
+    - name: Restore prod image
+      env:
+        LOAD_FILE: ${{ runner.temp }}/images/${{ needs.build-prod.outputs.artifact-image }}
+        IMAGE_URL: ${{ needs.build-prod.outputs.image-url }}
+      run: |
+        docker image load --input "$LOAD_FILE"
+
+        docker image tag "$IMAGE_URL" quay.io/freedomofpress/securedroporg
+
+    - name: Start
+      run: |
+        docker compose --file="$COMPOSE_FILE_PROD" up --wait --detach --pull=missing --no-build
+
+        # Check for failed services and error if any are found
+        sleep 5
+        if [[ $(docker compose --file="$COMPOSE_FILE_PROD" ps --status='[restarting, dead, exited]' --format=json) ]]; then 
+          echo "ERROR: One or more services failed to start"
+          docker compose ps
+          exit 1
+        fi
+
+    - name: Verify django
+      run: |
+        docker run --pull=missing --rm --network=securedroporg_app "docker.io/curlimages/curl:$VERSION_CURL" \
+        --ipv4 --retry 24 --retry-delay 5 --retry-all-errors http://django:8000/health/ok/
+
+    - name: Verify database
+      run: |
+        docker compose --file="$COMPOSE_FILE_PROD" exec django \
+        /bin/bash -c "./manage.py createdevdata"
+
+    - name: Export logs
+      run: |
+        mkdir --parents ${{ runner.temp }}/logs
+        docker compose --file="$COMPOSE_FILE_PROD" logs django >${{ runner.temp }}/logs/django.log
+        docker compose --file="$COMPOSE_FILE_PROD" logs postgresql >${{ runner.temp }}/logs/postgresql.log
+
+    - name: Save logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-prod-${{ github.run_id }}-logs
+        path: ${{ runner.temp }}/logs
+        if-no-files-found: error
+        overwrite: true
+        retention-days: 5
+
   cleanup:
-    name: Build:Cleanup
+    name: Cleanup
     runs-on: ubuntu-latest
     needs: 
     - build-dev
+    - build-node
+    - build-prod
     - test
-    if: ${{ needs.build-dev.result == 'success' && always() }}
+    - test-prod
     permissions:
       contents: read
       actions: write
+    if: ${{ always() }}
     steps:
-    - name: Delete built images
+    - name: Delete dev image
+      if: ${{ needs.build-dev.result == 'success' && always() }}
       uses: freedomofpress/actionslib/act/delete-artifact@main
       with:
-        artifact: ${{ needs.build-dev.outputs.images }}
+        artifact: ${{ needs.build-dev.outputs.artifact-name }}
+        error-if-absent: 'false'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Delete node image
+      if: ${{ needs.build-node.result == 'success' && always() }}
+      uses: freedomofpress/actionslib/act/delete-artifact@main
+      with:
+        artifact: ${{ needs.build-node.outputs.artifact-name }}
+        error-if-absent: 'false'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Delete prod image
+      if: ${{ needs.build-prod.result == 'success' && always() }}
+      uses: freedomofpress/actionslib/act/delete-artifact@main
+      with:
+        artifact: ${{ needs.build-prod.outputs.artifact-name }}
         error-if-absent: 'false'
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,5 @@
 ---
-name: Testing
+name: Publish
 
 on:
   push:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,52 @@
+---
+name: Testing
+
+on:
+  push:
+    branches:
+    - develop
+    - staging
+    - prod
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+    - name: Determine tags
+      id: tags
+      env:
+        BRANCH: ${{ github.ref_name }}
+        SHA: ${{ github.sha }}
+      run: |
+        export TAGS="$BRANCH;$BRANCH-${SHA:0:7}"
+
+        if [ "$BRANCH" = "prod" ]; then
+          export TAGS="$TAGS;latest"
+        fi
+
+        echo "tags=$TAGS" >>$GITHUB_OUTPUT
+    outputs:
+      tags: ${{ steps.tags.outputs.tags }}
+
+  build:
+    name: Build
+    uses: freedomofpress/actionslib/.github/workflows/oci-build.yaml@main
+    needs:
+    - prepare
+    permissions:
+      contents: read
+      actions: read
+      packages: write
+    with:
+      context: "."
+      containerfile: devops/docker/ProdDjangoDockerfile
+      build-args: USERID=12345
+      tags: ${{ needs.prepare.outputs.tags }}
+      requires-deep-history: true
+      registry: ghcr.io/freedomofpress/securedroporg
+    

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,9 +26,10 @@ services:
         USERID: ${UID:?err}
     image: localhost/securedroporg-node
     volumes:
-      - ./:/django
+      - ./:/django:z
     working_dir: /django
     user: ${UID:?err}
+    userns_mode: keep-id
     networks:
       - app
 
@@ -54,8 +55,9 @@ services:
       DEPLOY_ENV: dev
       DJANGO_ONION_HOSTNAME: secrdrop5wyphb5x.onion
     working_dir: /django
+    userns_mode: keep-id
     volumes:
-      - ./:/django
+      - ./:/django:z
     ports:
       - "127.0.0.1:8000:8000"
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       dockerfile: devops/docker/NodeDockerfile
       args:
         USERID: ${UID:?err}
+    image: localhost/securedroporg-node
     volumes:
       - ./:/django
     working_dir: /django
@@ -39,6 +40,7 @@ services:
       dockerfile: devops/docker/DevDjangoDockerfile
       args:
         USERID: ${UID:?err}
+    image: localhost/securedroporg-django
     depends_on:
       - node
       - postgresql


### PR DESCRIPTION
Fixes #1190 

## Description

* Adds support building and publishing an OCI image whenever changes are merged into `develop` that will be tagged with `develop` and `develop-<sha>`.
* Adds support building and publishing an OCI image whenever changes are merged into `staging` that will be tagged with `staging` and `staging-<sha>`.
* Adds support building and publishing an OCI image whenever changes are merged into `prod` that will be tagged with `prod`, `prod-<sha>`, and `latest`.
* Update the `ci` workflow to use the new build infrastructure

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field