### PR TITLE
fix: update GitHub actions to current versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         version: ${{ env.VERSION_DOCKER }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: true
 
@@ -160,7 +160,7 @@ jobs:
         version: ${{ env.VERSION_DOCKER }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,7 @@ jobs:
         docker compose --file="$COMPOSE_FILE_DEV" logs postgresql >${{ runner.temp }}/logs/postgresql.log
     
     - name: Save logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-${{ matrix.target }}-${{ github.run_id }}-logs
         path: ${{ runner.temp }}/logs
@@ -139,7 +139,7 @@ jobs:
         retention-days: 5
 
     - name: Save HTML coverage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ matrix.target == 'dev-tests' }}
       with:
         name: test-${{ matrix.target }}-${{ github.run_id }}-htmlcov
@@ -208,7 +208,7 @@ jobs:
         docker compose --file="$COMPOSE_FILE_PROD" logs postgresql >${{ runner.temp }}/logs/postgresql.log
 
     - name: Save logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-prod-${{ github.run_id }}-logs
         path: ${{ runner.temp }}/logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,13 +80,13 @@ jobs:
         persist-credentials: true
 
     - name: Download dev image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-dev.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
 
     - name: Download node image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-node.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
@@ -165,7 +165,7 @@ jobs:
         persist-credentials: true
 
     - name: Download prod image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-prod.outputs.artifact-name }}
         path: ${{ runner.temp }}/images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         - flake8
     steps:
     - name: Install Docker
-      uses: docker/setup-docker-action@v4
+      uses: docker/setup-docker-action@v5
       with:
         version: ${{ env.VERSION_DOCKER }}
 
@@ -155,7 +155,7 @@ jobs:
     - build-prod
     steps:
     - name: Install Docker
-      uses: docker/setup-docker-action@v4
+      uses: docker/setup-docker-action@v5
       with:
         version: ${{ env.VERSION_DOCKER }}
 


### PR DESCRIPTION
## Description
Update GitHub actions to current versions:
- update actions/download-artifact from v4 to v6
- update actions/checkout from v4 to v6
- update docker/setup-docker-action from v4 to v5
- update actions/upload-artifact from v4 to v7

Resolves deprecation warnings about Node v20.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
Ensure CI passes.