### PR TITLE
build: bump Pygments to 2.20.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1188,9 +1188,9 @@ pyflakes==3.1.0 \
     --hash=sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774 \
     --hash=sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
     # via flake8
-pygments==2.15.1 \
-    --hash=sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c \
-    --hash=sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via
     #   -r requirements.txt
     #   ipython

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ feedparser
 gunicorn>=20.1.0
 lxml>=4.9.3
 psycopg2>=2.9.9
-pygments
+pygments>=2.20.0
 python-json-logger
 structlog
 tldextract
@@ -27,4 +27,3 @@ django-csp>=3.7
 requests>=2.33.1
 wagtailmedia>=0.14.5
 whitenoise
-pygments>=2.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -748,9 +748,9 @@ pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
     # via cffi
-pygments==2.15.1 \
-    --hash=sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c \
-    --hash=sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via -r requirements.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \


### PR DESCRIPTION
## Description
This addresses a CVE in Pygments:
https://github.com/advisories/GHSA-5239-wwwm-4pmq: https://getsafety.com/vulnerabilities/SFTY-20260322-35073

This is a minor version upgrade for Pygments.

## Type of change
- [x] Vulnerabilities update

## Related issues:
FPF https://github.com/freedomofpress/pressfreedomtracker.us/pull/2124
PFT https://github.com/freedomofpress/pressfreedomtracker.us/pull/2124