### PR TITLE
Enable whitenoise packing when collecting static in production

### DIFF
--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -81,5 +81,5 @@ RUN tldextract --update
 RUN /django/devops/scripts/version-file.sh
 
 # since no django env is specified, runs in dev; disable DEBUG
-RUN env DJANGO_DISABLE_DEBUG=1 ./manage.py collectstatic -c --noinput
+RUN env DJANGO_WHITENOISE=1 DJANGO_DISABLE_DEBUG=1 ./manage.py collectstatic -c --noinput
 CMD django-start.sh

--- a/securedrop/templates/super.html
+++ b/securedrop/templates/super.html
@@ -44,10 +44,6 @@
 					{% endif %}
 				{% endwith %}
 			{% endblock %}
-
-			<!--[if lte IE 11]>
-			<script type="text/javascript" src="{% static 'js/picturefill.3.0.2.min.js' %}"></script>
-			<![endif]-->
 		{% endblock %}
 	</head>
 


### PR DESCRIPTION
## Description

The goal of this change is fixing static files in our staging environment.  Adding the `DJANGO_WHITENOISE` setting when running the collectstatic command brings this configuration into line with what [freedom.press is doing.](https://github.com/freedomofpress/freedom.press/blob/1614080e15d33391d40e0678714436c1dd409c07/devops/docker/ProdDjangoDockerfile#L72)  Additionally, we have `DJANGO_WHITENOISE=1` on the running application, and I think not having it when running the collectstatic command at build time is making it so the files can't be seen by the site.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

It's possible to test this locally with:

```
docker compose -f prod-docker-compose.yaml build
docker compose -f prod-docker-compose.yaml up
```

On this branch, the site should basically work and render static files correctly. On `develop`, it will fail with a "missing staticfiles manifest" error.
