### PR TITLE
fix: disable Gravatar in Wagtail admin

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -225,6 +225,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 # Wagtail settings
+WAGTAIL_GRAVATAR_PROVIDER_URL = None
 
 WAGTAIL_SITE_NAME = "securedrop"
 


### PR DESCRIPTION
## Description
Disables Gravatar in Wagtail admin. Was not needed by editorial and caused CSP errors.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

1. Go to http://localhost:8000/admin/. 
1. Log in
1. Observe generic person icon
2. Observe no CSP errors in console