### PR TITLE
Deploy 2026.04.29-2

### DIFF
--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Tuple, Dict, List
 
 import tldextract
 
-from datetime import timezone
+from datetime import datetime, timezone
 
 from directory.models import ScanResult, DirectoryEntry
 from scanner.utils import HEADERS
@@ -110,7 +110,7 @@ def bulk_scan(securedrops: 'DirectoryEntryQuerySet') -> None:
 
         if prior_result.is_equal_to(current_result):
             # Then let's not waste a row in the database
-            prior_result.result_last_seen = timezone.now()
+            prior_result.result_last_seen = datetime.now(timezone.utc)
             prior_result.save()
         else:
             # Then let's add this new scan result to the database

--- a/scanner/tests/test_scanner.py
+++ b/scanner/tests/test_scanner.py
@@ -1,7 +1,7 @@
 import os
 import re
 from unittest import mock
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 from django.test import TestCase
 import vcr
@@ -12,7 +12,7 @@ from scanner.tests.utils import (
     NON_EXISTENT_URL,
     requests_get_mock,
 )
-from directory.models import DirectoryEntry
+from directory.models import DirectoryEntry, ScanResult
 from directory.tests.factories import DirectoryEntryFactory
 
 
@@ -314,6 +314,43 @@ class ScannerTest(TestCase):
             self.assertEqual(
                 1, page.results.count()
             )
+
+    @mock.patch('scanner.scanner.perform_scan')
+    def test_bulk_scan_duplicate_result(self, mock_perform_scan):
+        entry = DirectoryEntryFactory.create(
+            title='News Org',
+            landing_page_url='https://newsorg.org',
+            onion_address='notreal.onion'
+        )
+
+        old_result = ScanResult.objects.create(
+            securedrop=entry,
+            landing_page_url=entry.landing_page_url,
+            redirect_target=None,
+            live=True,
+        )
+
+        # Update the last seen time, needed to evade
+        # `auto_now_add=True` on this field.
+        old_result.result_last_seen = (
+            datetime.now(timezone.utc) - timedelta(days=1)
+        )
+        old_result.save()
+
+        # Must match old result's fields.
+        mock_perform_scan.return_value = ScanResult(
+            landing_page_url=entry.landing_page_url,
+            redirect_target=None,
+            live=True,
+        )
+        securedrop_pages_qs = DirectoryEntry.objects.all()
+        scanner.bulk_scan(securedrop_pages_qs)
+
+        old_result.refresh_from_db()
+        self.assertTrue(
+            datetime.now(timezone.utc) - old_result.result_last_seen
+            < timedelta(seconds=10),
+        )
 
     @mod_vcr.use_cassette(os.path.join(VCR_DIR, 'bulk-scan-error-handling.yaml'))
     def test_bulk_scan_error_handling(self):


### PR DESCRIPTION
## Deploy changelog
* Fix bulk scanner's acquisition of the current time

## Pre-deploy Checklist

- [x] Verify basic CMS functionality (saving drafts, publishing changes) across content types
- [x] Verify directory filters (country/topic/language) work as expected
- [x] Verify directory search works as expected
- [x] Verify contact form submission works as expected (functionality may be limited in staging)
- [x] Verify that the directory scan result page in the admin interface loads as expected
- [x] Verify that the API at /api/v1/directory/ returns directory entries and scan results as expected
