### PR TITLE
fix: no longer pin pip to 25.0.1

### DIFF
--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 FROM python-base AS builder
 ARG PIP_COMPILE_ARGS
-RUN pip install -U pip==25.0.1 pip-tools wheel
+RUN pip install -U pip pip-tools wheel
 COPY dev-requirements.in requirements.in dev-requirements.txt requirements.txt ./
 COPY devops/docker/pip-compile.sh /usr/local/bin
 # Pass given pip compile arguments through to the pip compile script


### PR DESCRIPTION
## Description
No longer pin pip to 25.0.1.

The bug this worked around was fixed a while ago. https://github.com/freedomofpress/securedrop.org/commit/427d660e171ae8a109b6408d6b237ab1bcbcec77