### PR TITLE
fix: remove --keep-db from dev-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ci-tests: ## Runs testinfra against a pre-running CI container. Useful for debug
 .PHONY: dev-tests
 dev-tests: ## Run django tests against developer environment
 	docker compose exec django /bin/bash -ec \
-		"coverage run --source='.' ./manage.py test --noinput --keepdb; \
+		"coverage run --source='.' ./manage.py test --noinput; \
 		coverage html --skip-empty --omit='*/migrations/*.py,*/tests/*.py'; \
 		coverage report -m --fail-under=70 --skip-empty --omit='*/migrations/*.py,*/tests/*.py'"
 


### PR DESCRIPTION
## Description
- remove --keep-db from dev-tests
- matches PFT behaviour

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field