### PR TITLE
fix: add missing leading dashes and .html exception to .pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
         name: Enforce end of file format
-        exclude: '\.svg$|blog/static/pdf.js/build/.+\.js'
+        exclude: '\.svg$|\.html$|blog/static/pdf.js/build/.+\.js'
 
       - id: trailing-whitespace
         name: Enforce removal of trailing whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.9.0


### PR DESCRIPTION
## Description
Add missing leading dashes to .pre-commit-config. Likely lost in a merge.

Except HTML files from end-of-file-fixer (don't require a trailing newline).

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
