### PR TITLE
fix: add indent config for pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
----
 repos:
   - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.9.0
@@ -31,7 +30,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,8 @@ section-order = [
 [tool.ruff.lint.isort.sections]
 "django" = ["django"]
 "wagtail" = ["wagtail"]
+
+[tool.pre-commit-update.yaml]
+mapping = 2
+sequence = 4
+offset = 2


### PR DESCRIPTION
## Description
Add indent config for pre-commit update. Avoids whitespace thrash with prettier when pre-commit is updated.

Changes proposed in this pull request:
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
