### PR TITLE
Fix `pageurl` on initial blog autosave

### DIFF
--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -18,7 +18,7 @@
 	<div class="blog-page">
 		<div class="blog-title">
 			{% include "common/_hexagon.svg" with class="blog-title__hexagon" category_slug=page.category.slug %}
-			<h2 class="blog-title__category"><a href="{% pageurl page.category %}" class="blog-title__category-link">{{ page.category }}</a></h2>
+			<h2 class="blog-title__category"><a href="{% if page.category %}{% pageurl page.category %}{% endif %}" class="blog-title__category-link">{{ page.category }}</a></h2>
 			<h1 id="title">{{ page.title }}</h1>
 		</div>
 		<article>


### PR DESCRIPTION
When a new blog page is being autosaved after the first content is entered, if the preview pane is open, it will fail to render until the `category` field is populated, because our call to the `pageurl` templatetag includes `page.category`, which is `None`.

With the Wagtail 7.4 upgrade, deferred validation and autosave mean that the `category` is not required to save a page in progress, and so this template should render cleanly without the `category`.

I've chosen to make the URL empty instead of choosing an alternative. For a preview of the page, I think this fine. The model will require it before the page can be published. 

I also considered making the category required to save the page, but given that it appears on the page editor below the body and teaser fields, this didn't feel particular user-friendly for content editors. By adding the `if`/`else` to the template, a content editor can proceed down the page in field order and have autosave and preview work as expected.

This should stop some the large number of 500s we're seeing on initial page creation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

To reproduce the original error: on the `develop` branch, create a new blog page and without modifying any fields open the preview pane. You will see a `ValueError` on the line in this template that this PR changes. All changes you make except for adding a category will result in autosaves that refresh the preview pane and show this same `ValueError`. The `ValueError` will disappear once you enter a category.

Switch to this branch. create a new blog page and without modifying any fields open the preview pane. You will see a rendered preview of a blog post with nothing in it, and no `ValueError`, and no 500.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
