### PR TITLE
Add env var for `WAGTAIL_AUTOSAVE_INTERVAL`

### DIFF
--- a/securedrop/settings/base.py
+++ b/securedrop/settings/base.py
@@ -246,6 +246,10 @@ WAGTAILADMIN_COMMENTS_ENABLED = False
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "https://securedrop.org"
 
+# Wagtail autosave interval in ms. Sets how often to wait after the last attempt
+# to autosave before autosaving again. Wagtail default is 500.
+WAGTAIL_AUTOSAVE_INTERVAL = int(os.environ.get("WAGTAIL_AUTOSAVE_INTERVAL", 500))
+
 # Django-webpack configuration
 WEBPACK_LOADER = {
     "DEFAULT": {


### PR DESCRIPTION
This adds an env var for `WAGTAIL_AUTOSAVE_INTERVAL`, defaulting to 500ms, the [Wagtail default](https://docs.wagtail.org/en/v7.4.1/reference/settings.html#wagtail-autosave-interval). This gives us a knob to tweak in deployment to adjust autosave or turn it off (by setting it to `0`).

Part of https://github.com/freedomofpress/fpf-www-projects/issues/544

@enpaul and @conorsch for awareness.

## Type of change

- [x] Config changes

## Checklist

### General checks

- [x] Linting and tests pass locally
