### PR TITLE
fix: add continue-on-error: true to cleanup steps

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -234,6 +234,7 @@ jobs:
       - name: Delete dev image
         if: ${{ needs.build-dev.result == 'success' && always() }}
         uses: freedomofpress/actionslib/act/delete-artifact@main
+        continue-on-error: true
         with:
           artifact: ${{ needs.build-dev.outputs.artifact-name }}
           error-if-absent: 'false'
@@ -242,6 +243,7 @@ jobs:
       - name: Delete node image
         if: ${{ needs.build-node.result == 'success' && always() }}
         uses: freedomofpress/actionslib/act/delete-artifact@main
+        continue-on-error: true
         with:
           artifact: ${{ needs.build-node.outputs.artifact-name }}
           error-if-absent: 'false'
@@ -250,6 +252,7 @@ jobs:
       - name: Delete prod image
         if: ${{ needs.build-prod.result == 'success' && always() }}
         uses: freedomofpress/actionslib/act/delete-artifact@main
+        continue-on-error: true
         with:
           artifact: ${{ needs.build-prod.outputs.artifact-name }}
           error-if-absent: 'false'


### PR DESCRIPTION
## Description
Add continue-on-error: true to cleanup steps. Prevents the `cleanup` task from causing a CI run to fail.

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
