### PR TITLE
fix: set pip update limit to 10. zero was none, not infinity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       day: 'sunday'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
     allow:
       - dependency-type: 'all'
     commit-message:


### PR DESCRIPTION
## Description
Set pip update limit to 10. zero was none, not infinity.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
