### PR TITLE
Upgrade github webhook validation signing to sha-256

### DIFF
--- a/github/event_codes.py
+++ b/github/event_codes.py
@@ -18,6 +18,7 @@ EventCode = enum.IntEnum(
         "UnsupportedAction",
         "ReleaseAttributeMissing",
         "UnknownRepository",
+        "SignatureNotSha256",
     ],
     # This start value is designed to be unique for the "github" app.
     # Other apps should use a different start value that does not

--- a/github/management/commands/replay_release_webhook.py
+++ b/github/management/commands/replay_release_webhook.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
             ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         body = json.dumps(payload).encode("utf-8")
-        signature = hmac.new(secret, msg=body, digestmod=hashlib.sha1).hexdigest()
+        signature = hmac.new(secret, msg=body, digestmod=hashlib.sha256).hexdigest()
 
         req = urllib_request.Request(
             options["url"],
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             headers={
                 "Content-Type": "application/json",
                 "X-GitHub-Event": "release",
-                "X-Hub-Signature": "sha1={}".format(signature),
+                "X-Hub-Signature-256": "sha256={}".format(signature),
             },
             method="POST",
         )

--- a/github/tests/test_receive_hook.py
+++ b/github/tests/test_receive_hook.py
@@ -28,7 +28,7 @@ class TestReceiveHook(TestCase):
             github_event (str): The X-GitHub-Event header, defaults to
                 "release".
 
-            signature (str): The X-Hub-Signature header, defaults to the
+            signature (str): The X-Hub-Signature-256 header, defaults to the
                 correct composition of digestmod and digest.
         """
         json_path = os.path.join(
@@ -40,7 +40,7 @@ class TestReceiveHook(TestCase):
             mac = hmac.new(
                 secret,
                 msg=payload_digest_func(payload).encode("utf-8"),
-                digestmod=hashlib.sha1,
+                digestmod=hashlib.sha256,
             )
 
         return self.client.post(
@@ -49,8 +49,8 @@ class TestReceiveHook(TestCase):
             content_type="application/json",
             headers={
                 "x-github-event": kwargs.get("github_event", "release"),
-                "x-hub-signature": kwargs.get(
-                    "signature", "sha1={}".format(mac.hexdigest())
+                "x-hub-signature-256": kwargs.get(
+                    "signature", "sha256={}".format(mac.hexdigest())
                 ),
             },
         )

--- a/github/views.py
+++ b/github/views.py
@@ -16,22 +16,22 @@ from .event_codes import EventCode
 logger = structlog.get_logger()
 
 
-def validate_sha1_signature(request, secret):
-    # X-Hub-Signature is the "HMAC hex digest of the payload, using the hook's
-    # secret as the key."
-    digest = request.headers.get("x-hub-signature", None)
+def validate_sha256_signature(request, secret):
+    # X-Hub-Signature-256 is the "HMAC hex digest of the payload, using the
+    # hook's secret as the key."
+    digest = request.headers.get("x-hub-signature-256", None)
     if not digest or digest.count("=") != 1:
         return False
     digestmod, signature = digest.split("=")
-    if digestmod != "sha1":
-        logger.warn(
-            "SHA1 signature validation failed due to signature of type other than sha1",
+    if digestmod != "sha256":
+        logger.warning(
+            "Signature validation failed due to signature of type other than sha256",
             github_digest=digest,
-            event_code=EventCode.SignatureNotSha1,
+            event_code=EventCode.SignatureNotSha256,
         )
         return False
 
-    mac = hmac.new(secret, msg=request.body, digestmod=hashlib.sha1)
+    mac = hmac.new(secret, msg=request.body, digestmod=hashlib.sha256)
     return hmac.compare_digest(mac.hexdigest(), signature)
 
 
@@ -94,7 +94,7 @@ def receive_hook(request):
         )
         return HttpResponse(status=204)
 
-    if not validate_sha1_signature(request, settings.GITHUB_HOOK_SECRET_KEY):
+    if not validate_sha256_signature(request, settings.GITHUB_HOOK_SECRET_KEY):
         logger.warn(
             "GitHub hook received event with an invalid signature.",
             event_code=EventCode.InvalidSignature,


### PR DESCRIPTION
## Description

replacing #1308 which I've made a mess of. the intended changeset is very small. 

Changes proposed in this pull request:

replace sha-1 validation with sha-256. 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
