### PR TITLE
Ensure that pages can be rendered before validation

### DIFF
--- a/home/templates/home/_instances.html
+++ b/home/templates/home/_instances.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags	%}
 {% for highlighted_instance in instances %}
-	<a href="{% pageurl highlighted_instance.instance %}" class="instances__item" aria-label="{{ page.instance_link_default_text }}: {{ highlighted_instance.instance.title }}">
+	<a href="{% if highlighted_instance.instance %}{% pageurl highlighted_instance.instance %}{% endif %}" class="instances__item" aria-label="{{ page.instance_link_default_text }}: {{ highlighted_instance.instance.title }}">
 		{% if highlighted_instance.instance.organization_logo_homepage %}
 			{% image highlighted_instance.instance.organization_logo_homepage max-96x96 preserve-svg as logo_1x %}
 			{% image highlighted_instance.instance.organization_logo_homepage max-192x192 preserve-svg as logo_2x %}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -35,7 +35,7 @@
 			{% endif %}
 
 			{% for button in page.description_buttons.all %}
-				<a href="{% pageurl button.link %}" class="hero__button">
+				<a href="{% if button.link %}{% pageurl button.link %}{% endif %}" class="hero__button">
 					{{ button.text }}
 					{% include "common/chevron-right.svg" with class="hero__button-icon" %}
 				</a>
@@ -54,7 +54,7 @@
 				<section class="updates__section">
 					<h2 class="updates__header">{% trans "Latest News" %}</h2>
 					<article class="updates__item">
-						<a href="{% pageurl self.get_latest_blog %}" class="updates__link">{{ self.get_latest_blog }}</a>
+						<a href="{% if self.get_latest_blog %}{% pageurl self.get_latest_blog %}{% endif %}" class="updates__link">{{ self.get_latest_blog }}</a>
 					</article>
 				</section>
 				{% with latest_releases=page.get_latest_releases %}
@@ -107,7 +107,7 @@
 					</div>
 				{% endwith %}
 				{% for button in page.instance_button.all %}
-					<a href="{% pageurl button.link %}" class="instances__button">
+					<a href="{% if button.link %}{% pageurl button.link %}{% endif %}" class="instances__button">
 						{{ button.text }}
 						{% include "common/chevron-right.svg" with class="instances__button-icon" %}
 					</a>
@@ -121,7 +121,7 @@
 			{% endif %}
 			{% include "marketing/_features_list.html" with features=page.features.all %}
 			{% for button in page.features_button.all %}
-				<a href="{% pageurl button.link %}" class="features__button">
+				<a href="{% if button.link %}{% pageurl button.link %}{% endif %}" class="features__button">
 					{{ button.text }}
 					{% include "common/chevron-right.svg" with class="features__button-icon" %}
 				</a>


### PR DESCRIPTION
This is a few small, relatively hard-to-hit fixes to `pageurl` calls in templates that can theoretically prevent page drafts from being rendered by the preview pane in the Wagtail admin (because they raise exceptions/generate 500 errors) since Wagtail 7.0's deferred validation. Deferred validation means that fields and blocks can be saved with blank values but are still expected to be previewable.

We already fixed a couple of the most pressing of these in #1304. The remaining issues that this fixes are unlikely to be encountered in practical terms (how often do we create a new HomePage?), but this guards against them anyway.

This addresses https://github.com/freedomofpress/fpf-www-projects/issues/552 for securedrop.org.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

With this change, creating a new page type, with all available fields blank, and with all block options added and blank, should still successfully preview in the preview pane in the Wagtail admin. The only pages fixed in this PR is HomePage, guarding against blank highlighted instances, and description links (`description_buttons` in the model, "Links" in the admin).

But, as in https://github.com/freedomofpress/freedom.press/pull/2955 and https://github.com/freedomofpress/pressfreedomtracker.us/pull/2286, any page and combination of page blocks and fields may be blank and the preview pane will still render without error, so manually testing other possibilities is still recommended.

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to directory listing:

- [ ] Verify directory filters (country/topic/language) work as expected
- [ ] Verify directory search works as expected

### If you made changes to contact form

- [ ] Verify contact form submissions works as expected
- [ ] Verify if any CSP changes required (test at least both firefox & chrome)

### If you made changes to scanner

- [ ] Verify that the directory scan result page in admin interface loads as expected
- [ ] Verify that the API at `/api/v1/directory` returns directory entries and scan results as expected

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
