### PR TITLE
fix: remove nonexistent “staging” branch from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - staging
       - prod
       - experimental
 


### PR DESCRIPTION
## Description
Remove nonexistent “staging” branch from publish workflow

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field