### PR TITLE
ci: don't pull an image just for curl

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -109,16 +109,7 @@ jobs:
         run: make dev-init
 
       - name: Start
-        run: |
-          docker compose --file="$COMPOSE_FILE_DEV" up --wait --pull=missing --no-build
-
-          # Check for failed services and error if any are found
-          sleep 5
-          if [[ $(docker compose --file="$COMPOSE_FILE_DEV" ps --status='[restarting, dead, exited]' --format=json) ]]; then
-            echo "ERROR: One or more services failed to start"
-            docker compose ps
-            exit 1
-          fi
+        run: docker compose --file="$COMPOSE_FILE_DEV" up --wait --wait-timeout=180 --detach --pull=missing --no-build
 
       - name: Make target ${{ matrix.target }}
         run: make ${{ matrix.target }}
@@ -181,21 +172,7 @@ jobs:
           docker image tag "$IMAGE_URL" quay.io/freedomofpress/securedroporg
 
       - name: Start
-        run: |
-          docker compose --file="$COMPOSE_FILE_PROD" up --wait --pull=missing --no-build
-
-          # Check for failed services and error if any are found
-          sleep 5
-          if [[ $(docker compose --file="$COMPOSE_FILE_PROD" ps --status='[restarting, dead, exited]' --format=json) ]]; then
-            echo "ERROR: One or more services failed to start"
-            docker compose ps
-            exit 1
-          fi
-
-      - name: Verify django
-        run: |
-          docker run --pull=missing --rm --network=securedroporg_app "docker.io/curlimages/curl:$VERSION_CURL" \
-          --ipv4 --retry 24 --retry-delay 5 --retry-all-errors http://django:8000/health/ok/
+        run: docker compose --file="$COMPOSE_FILE_PROD" up --wait --wait-timeout=180 --detach --pull=missing --no-build
 
       - name: Verify database
         run: |

--- a/devops/docker/NodeDockerfile
+++ b/devops/docker/NodeDockerfile
@@ -3,6 +3,10 @@ FROM node:26.5.0-trixie@sha256:0473e7dc433a1310f436edee02aa79737ec78a4b345433ab0
 
 ARG USERID
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN getent passwd "${USERID}" || useradd --create-home --no-log-init --uid "${USERID}" sdo_node
 
 USER ${USERID}

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     libz-dev \
     netcat-traditional \
     python3-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 
 COPY devops/docker/django-start.sh /usr/local/bin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,10 @@ services:
       - ./:/django:z
     working_dir: /django
     user: ${UID:?err}
+    healthcheck:
+      test: jq '.status' webpack-stats.json |grep -q -e compiling -e error -e done
+      interval: 10s
+      start_period: 1m30s
     userns_mode: keep-id
     networks:
       - app
@@ -43,8 +47,10 @@ services:
         USERID: ${UID:?err}
     image: localhost/securedroporg-django
     depends_on:
-      - node
-      - postgresql
+      postgresql:
+        condition: service_healthy
+      node:
+        condition: service_healthy
     environment:
       DJANGO_DB_PASSWORD: securedroppassword
       DJANGO_DB_USER: securedrop
@@ -61,6 +67,13 @@ services:
       - ./:/django:z
     ports:
       - '127.0.0.1:8000:8000'
+    healthcheck:
+      test:
+        ['CMD', 'curl', '--fail', 'http://localhost:8000/health/ok/?monitor']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 45s
     networks:
       app:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,12 @@
 ---
 networks:
   app:
+
+x-variables:
+  db-name: &db-name securedropdb
+  db-username: &db-username securedrop
+  db-password: &db-password securedroppassword
+
 services:
   postgresql:
     image: postgres:14
@@ -9,10 +15,26 @@ services:
     volumes:
       - ./:/django:ro
     environment:
-      POSTGRES_PASSWORD: securedroppassword
-      POSTGRES_USER: securedrop
-      POSTGRES_DB: securedropdb
+      POSTGRES_PASSWORD: *db-password
+      POSTGRES_USER: *db-username
+      POSTGRES_DB: *db-name
     user: postgres
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'pg_isready',
+          '-q',
+          '-h',
+          'localhost',
+          '-U',
+          *db-username,
+          '--dbname',
+          *db-name,
+        ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
     networks:
       app:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
     working_dir: /django
     user: ${UID:?err}
     healthcheck:
-      test: jq '.status' webpack-stats.json |grep -q -e compiling -e error -e done
+      test: jq '.status' build/static/bundles/webpack-stats.json |grep -q -e compiling -e error -e done
       interval: 10s
       start_period: 1m30s
     userns_mode: keep-id

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -11,6 +11,22 @@ services:
       POSTGRES_USER: securedrop
       POSTGRES_DB: securedropdb
     user: postgres
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'pg_isready',
+          '-q',
+          '-h',
+          'localhost',
+          '-U',
+          'freedompress',
+          '--dbname',
+          'freedompressdb',
+        ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
     networks:
       app:
         aliases:
@@ -24,7 +40,8 @@ services:
         USERID: 12345
     image: quay.io/freedomofpress/securedroporg
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     working_dir: /django
     volumes:
       - ${HOST_STATIC_DIR:-sdorg-django-media}:/django-media
@@ -46,12 +63,18 @@ services:
       DJANGO_MEDIA_ROOT: /django-media
       DEPLOY_ENV: prod
       DJANGO_WHITENOISE: 'True'
-    ports:
-      - '8000:8000'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/health/ok/']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 45s
     networks:
       app:
         aliases:
           - app
+    ports:
+      - '8000:8000'
 
 volumes:
   sdorg-django-static:

--- a/securedrop/settings/dev.py
+++ b/securedrop/settings/dev.py
@@ -39,6 +39,13 @@ structlog.configure(
     cache_logger_on_first_use=cache_logger,
 )
 
+
+def silence_monitoring(record):
+    if "GET /health/ok/?monitor" in record.getMessage():
+        return False
+    return True
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -46,7 +53,7 @@ LOGGING = {
         "normal": {
             "class": "logging.StreamHandler",
             "formatter": "plain_console",
-            "filters": ["require_debug_true"],
+            "filters": ["silence_monitoring", "require_debug_true"],
         },
         "null": {"class": "logging.NullHandler"},
     },
@@ -58,6 +65,10 @@ LOGGING = {
         },
     },
     "filters": {
+        "silence_monitoring": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": silence_monitoring,
+        },
         "require_debug_true": {
             "()": "django.utils.log.RequireDebugTrue",
         },


### PR DESCRIPTION
## Description
Same as https://github.com/freedomofpress/freedom.press/pull/3089, but for SDO
We were pulling an external image simply to run `curl` against the django service. We already have curl inside the django container, so let's just use it.

<details>
<summary>
example CI failure logs
</summary>

```
Run docker run --pull=missing --rm --network=freedompress_app "docker.io/curlimages/curl:latest" \
  docker run --pull=missing --rm --network=freedompress_app "docker.io/curlimages/curl:latest" \
  --ipv4 --retry 24 --retry-delay 5 --retry-all-errors http://django:8000/health/ok/
  shell: /usr/bin/bash -e {0}
  env:
    VERSION_DOCKER: latest
    COMPOSE_FILE_DEV: docker-compose.yaml
    COMPOSE_FILE_PROD: prod-docker-compose.yaml
Unable to find image 'curlimages/curl:latest' locally
latest: Pulling from curlimages/curl
8015b0f4edbc: Pulling fs layer
8015b0f4edbc: Download complete
8015b0f4edbc: Pull complete
Digest: sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
Status: Downloaded newer image for curlimages/curl:latest
curl: (6) Could not resolve host: django
Warning: Problem : timeout. Retrying in 5 seconds. 24 retries left.
```
</details>

A few things in [that failed run](https://github.com/freedomofpress/freedom.press/actions/runs/29507956189/job/87658450175) stand out immediately:

1. We're pulling a container image from a remote registry in order to run `curl`, when our images already have it.
2. We're communicating cross-network rather than intra-network to poll the healthcheck endpoint.
3. We're manually running a bespoke command to poll for app readiness, rather than using a first-class healthcheck block via compose.

The solution in this PR addresses all of those points, and should prove more stable on future CI runs.

## Scope of changes

This PR only affects CI behavior, in order to reduce failure rate, so no concerns for live deployments.