### PR TITLE
fix: apply pip and npm updates quarterly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,11 +19,9 @@ updates:
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'sunday'
+      interval: 'quarterly'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     allow:
       - dependency-type: 'all'
     commit-message:
@@ -42,11 +40,9 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'sunday'
+      interval: 'quarterly'
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     allow:
       - dependency-type: 'all'
     commit-message:


### PR DESCRIPTION
## Description
Now that we are up to date, switch back to applying pip and npm updates quarterly. Security updates will continue to be applied as soon as they are available.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field