### PR TITLE
fix: use cronjob for quarterly schedule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,7 +19,8 @@ updates:
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-      interval: 'quarterly'
+      interval: 'cron'
+      cronjob: '0 0 1 1,4,7,10 *'
     cooldown:
       default-days: 7
     allow:
@@ -40,7 +41,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'quarterly'
+      interval: 'cron'
+      cronjob: '0 0 1 1,4,7,10 *'
     cooldown:
       default-days: 7
     allow:


### PR DESCRIPTION
## Description
`interval: 'quarterly'` is only available in GitHub enterprise. Use a cron schedule instead.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field