### PR TITLE
fix: support selinux in compose mounts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     ports:
       - '127.0.0.1:5432:5432'
     volumes:
-      - ./:/django:ro
+      - ./:/django:ro,z
     environment:
       POSTGRES_PASSWORD: *db-password
       POSTGRES_USER: *db-username


### PR DESCRIPTION
## Description
When SELinux is set to enforcing, we need the "z" flag on volume mounts to ensure that the mounted files are labeled correctly.

Follow-up to https://github.com/freedomofpress/securedrop.org/pull/1566

Refs: 

* https://github.com/freedomofpress/freedom.press/pull/3269#issuecomment-5446738918
* https://github.com/freedomofpress/infrastructure/issues/6967

## Testing

Someone running `podman-compose` locally with SELinux on Fedora Workstation should confirm this change allows them to work. I overlooked this on the container logic before, and broke volume-mounting for fedora hosts. Should be resolved now.