### PR TITLE
build: update postgres from 14 to 17

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -5,3 +5,7 @@ ignored:
   # builds silently whenever Debian trixie rotates a version, for no real
   # reproducibility gain.
   - DL3008
+  # We ensure that containers are run in prod with `runAsUser: 1000`,
+  # and also port dev UIDs into the container build, so we're sufficiently
+  # defensive about UIDs within the container.
+  - DL3066

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ x-variables:
 
 services:
   postgresql:
-    image: docker.io/library/postgres:14
+    image: docker.io/library/postgres:17
     init: true
     ports:
       - '127.0.0.1:5432:5432'

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -3,7 +3,7 @@ networks:
   app:
 services:
   postgresql:
-    image: docker.io/library/postgres:14
+    image: docker.io/library/postgres:17
     init: true
     ports:
       - '5432'


### PR DESCRIPTION
## Description
Update the development environment from postgres from 14 to 17.

See related work from infra for experimental, staging and production: https://github.com/freedomofpress/infrastructure/issues/6886#issuecomment-5238079271

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
